### PR TITLE
Assertion in bytes in python3

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -4,7 +4,7 @@ try:  # Python 2
 except:  # Python 3
     from urllib.parse import urljoin
 import logging
-from base64 import b64encode
+from base64 import urlsafe_b64encode
 import sys
 
 from .oauth2cli import Client, JwtSigner
@@ -405,7 +405,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
             raise RuntimeError(
                 "RSTR returned unknown token type: %s", wstrust_result.get("type"))
         return self.client.obtain_token_by_assertion(
-            b64encode(wstrust_result["token"]),
+            urlsafe_b64encode(wstrust_result["token"]).strip(b'='),
             grant_type=grant_type, scope=scopes, **kwargs)
 
 

--- a/msal/application.py
+++ b/msal/application.py
@@ -4,7 +4,6 @@ try:  # Python 2
 except:  # Python 3
     from urllib.parse import urljoin
 import logging
-from base64 import urlsafe_b64encode
 import sys
 
 from .oauth2cli import Client, JwtSigner
@@ -404,9 +403,10 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
         if not grant_type:
             raise RuntimeError(
                 "RSTR returned unknown token type: %s", wstrust_result.get("type"))
+        self.client.grant_assertion_encoders.setdefault(  # Register a non-standard type
+            grant_type, self.client.encode_saml_assertion)
         return self.client.obtain_token_by_assertion(
-            urlsafe_b64encode(wstrust_result["token"]).strip(b'='),
-            grant_type=grant_type, scope=scopes, **kwargs)
+            wstrust_result["token"], grant_type, scope=scopes, **kwargs)
 
 
 class ConfidentialClientApplication(ClientApplication):  # server-side web app

--- a/msal/oauth2cli/assertion.py
+++ b/msal/oauth2cli/assertion.py
@@ -7,7 +7,7 @@ import logging
 import jwt
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 class Signer(object):
     def sign_assertion(

--- a/msal/oauth2cli/authcode.py
+++ b/msal/oauth2cli/authcode.py
@@ -21,7 +21,7 @@ except ImportError:  # Fall back to Python 2
 from .oauth2 import Client
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 def obtain_auth_code(listen_port, auth_uri=None):
     """This function will start a web server listening on http://localhost:port

--- a/msal/wstrust_request.py
+++ b/msal/wstrust_request.py
@@ -36,7 +36,7 @@ from .mex import Mex
 from .wstrust_response import parse_response
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 def send_request(
         username, password, cloud_audience_urn, endpoint_address, soap_action,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -97,6 +97,7 @@ class TestClient(Oauth2TestCase):
                         audience=CONFIG["openid_configuration"]["token_endpoint"],
                         issuer=CONFIG["client_id"],
                     ),
+                client_assertion_type=Client.CLIENT_ASSERTION_TYPE_JWT,
                 )
         else:
             cls.client = Client(


### PR DESCRIPTION
This PR is a superset of existing PR #11.

~The major part is equivalent, but here it is done the otherway around, i.e. `b"." in data_in_bytes` rather than `"." in data_in_bytes.decode()`. This way we deal with `bytes` directly, and save an ad-hoc type conversion. (On a side note, another alternative is to normalize the input into `string` at the very beginning and keep it, that would bring some handy benefit when later we want to log it. But the major drawback is the underlying requests library is technically [expecting bytes (per their documentation)](http://docs.python-requests.org/en/master/api/#requests.request), and actually [converting strings into bytes under the hood](https://github.com/requests/requests/blob/v2.21.0/requests/models.py#L103-L104). So normalizing-to-string would be a double performance penalty.) This PR also applies the same fix on acquire_token_by_assertion(), which is used in ADFS federated scenario.~ UPDATE: Based on the latest conversation in this PR, we head to a new direction by avoiding such tricky `if b"." in assertion` in the first place.

Lastly, we fine tune the relevant logging behavior.

You can test this PR by:

    pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@assertion-in-bytes-in-python3