### PR TITLE
Full support for verify and proxies

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -97,7 +97,7 @@ class ClientApplication(object):
         self.timeout = timeout
         self.authority = Authority(
                 authority or "https://login.microsoftonline.com/common/",
-                validate_authority, verify=self.verify, proxies=self.proxies)
+                validate_authority, verify=verify, proxies=proxies, timeout=timeout)
             # Here the self.authority is not the same type as authority in input
         self.token_cache = token_cache or TokenCache()
         self.client = self._build_client(client_credential, self.authority)
@@ -167,7 +167,8 @@ class ClientApplication(object):
             sending them on the wire.)
         """
         the_authority = Authority(
-            authority, verify=self.verify, proxies=self.proxies,
+            authority,
+            verify=self.verify, proxies=self.proxies, timeout=self.timeout,
             ) if authority else self.authority
         client = Client(
             {"authorization_endpoint": the_authority.authorization_endpoint},
@@ -275,7 +276,8 @@ class ClientApplication(object):
         """
         assert isinstance(scopes, list), "Invalid parameter type"
         the_authority = Authority(
-            authority, verify=self.verify, proxies=self.proxies,
+            authority,
+            verify=self.verify, proxies=self.proxies, timeout=self.timeout,
             ) if authority else self.authority
 
         if not force_refresh:
@@ -393,7 +395,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
         if user_realm_result.get("federation_metadata_url"):
             wstrust_endpoint = mex_send_request(
                 user_realm_result["federation_metadata_url"],
-                verify=self.verify, proxies=self.proxies)
+                verify=verify, proxies=proxies)
         logger.debug("wstrust_endpoint = %s", wstrust_endpoint)
         wstrust_result = wst_send_request(
             username, password, user_realm_result.get("cloud_audience_urn"),

--- a/msal/application.py
+++ b/msal/application.py
@@ -92,14 +92,14 @@ class ClientApplication(object):
         """
         self.client_id = client_id
         self.client_credential = client_credential
-        self.authority = Authority(
-                authority or "https://login.microsoftonline.com/common/",
-                validate_authority)
-            # Here the self.authority is not the same type as authority in input
-        self.token_cache = token_cache or TokenCache()
         self.verify = verify
         self.proxies = proxies
         self.timeout = timeout
+        self.authority = Authority(
+                authority or "https://login.microsoftonline.com/common/",
+                validate_authority, verify=self.verify, proxies=self.proxies)
+            # Here the self.authority is not the same type as authority in input
+        self.token_cache = token_cache or TokenCache()
         self.client = self._build_client(client_credential, self.authority)
 
     def _build_client(self, client_credential, authority):
@@ -166,7 +166,9 @@ class ClientApplication(object):
             (Under the hood, we simply merge scope and additional_scope before
             sending them on the wire.)
         """
-        the_authority = Authority(authority) if authority else self.authority
+        the_authority = Authority(
+            authority, verify=self.verify, proxies=self.proxies,
+            ) if authority else self.authority
         client = Client(
             {"authorization_endpoint": the_authority.authorization_endpoint},
             self.client_id)
@@ -272,7 +274,9 @@ class ClientApplication(object):
             - None when cache lookup does not yield anything.
         """
         assert isinstance(scopes, list), "Invalid parameter type"
-        the_authority = Authority(authority) if authority else self.authority
+        the_authority = Authority(
+            authority, verify=self.verify, proxies=self.proxies,
+            ) if authority else self.authority
 
         if not force_refresh:
             matches = self.token_cache.find(

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -21,7 +21,9 @@ class Authority(object):
     Once constructed, it contains members named "*_endpoint" for this instance.
     TODO: It will also cache the previously-validated authority instances.
     """
-    def __init__(self, authority_url, validate_authority=True):
+    def __init__(self, authority_url, validate_authority=True,
+            verify=True, proxies=None,
+            ):
         """Creates an authority instance, and also validates it.
 
         :param validate_authority:
@@ -30,24 +32,29 @@ class Authority(object):
             This parameter only controls whether an instance discovery will be
             performed.
         """
+        self.verify = verify
+        self.proxies = proxies
         canonicalized, self.instance, tenant = canonicalize(authority_url)
         tenant_discovery_endpoint = (  # Hard code a V2 pattern as default value
             'https://{}/{}/v2.0/.well-known/openid-configuration'
             .format(WORLD_WIDE, tenant))
         if validate_authority and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS:
             tenant_discovery_endpoint = instance_discovery(
-                canonicalized + "/oauth2/v2.0/authorize")
-        openid_config = tenant_discovery(tenant_discovery_endpoint)
+                canonicalized + "/oauth2/v2.0/authorize",
+                verify=verify, proxies=proxies)
+        openid_config = tenant_discovery(
+            tenant_discovery_endpoint, verify=verify, proxies=proxies)
         self.authorization_endpoint = openid_config['authorization_endpoint']
         self.token_endpoint = openid_config['token_endpoint']
         _, _, self.tenant = canonicalize(self.token_endpoint)  # Usually a GUID
         self.is_adfs = self.tenant.lower() == 'adfs'
 
-    def user_realm_discovery(self, username, **kwargs):
+    def user_realm_discovery(self, username):
         resp = requests.get(
             "https://{netloc}/common/userrealm/{username}?api-version=1.0".format(
                 netloc=self.instance, username=username),
-            headers={'Accept':'application/json'}, **kwargs)
+            headers={'Accept':'application/json'},
+            verify=self.verify, proxies=self.proxies)
         resp.raise_for_status()
         return resp.json()
         # It will typically contain "ver", "account_type",
@@ -64,17 +71,20 @@ def canonicalize(url):
             "https://login.microsoftonline.com/<tenant_name>" % url)
     return match_object.group(0), match_object.group(1), match_object.group(2)
 
-def instance_discovery(url, response=None):  # Returns tenant discovery endpoint
+def instance_discovery(url, response=None, verify=True, proxies=None):
+    # Returns tenant discovery endpoint
     resp = requests.get(  # Note: This URL seemingly returns V1 endpoint only
         'https://{}/common/discovery/instance'.format(WORLD_WIDE),
-        params={'authorization_endpoint': url, 'api-version': '1.0'})
+        params={'authorization_endpoint': url, 'api-version': '1.0'},
+        verify=verify, proxies=proxies)
     payload = response or resp.json()
     if 'tenant_discovery_endpoint' not in payload:
         raise MsalServiceError(status_code=resp.status_code, **payload)
     return payload['tenant_discovery_endpoint']
 
-def tenant_discovery(tenant_discovery_endpoint):  # Returns Openid Configuration
-    resp = requests.get(tenant_discovery_endpoint)
+def tenant_discovery(tenant_discovery_endpoint, verify=True, proxies=None):
+    # Returns Openid Configuration
+    resp = requests.get(tenant_discovery_endpoint, verify=verify, proxies=proxies)
     payload = resp.json()
     if 'authorization_endpoint' in payload and 'token_endpoint' in payload:
         return payload

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -94,6 +94,6 @@ class TestAuthorityInternalHelperInstanceDiscovery(unittest.TestCase):
     def test_instance_discovery_with_mocked_response(self):
         mock_response = {'tenant_discovery_endpoint': 'http://a.com/t/openid'}
         endpoint = instance_discovery(
-            "https://login.microsoftonline.in/tenant.com", mock_response)
+            "https://login.microsoftonline.in/tenant.com", response=mock_response)
         self.assertEqual(endpoint, mock_response['tenant_discovery_endpoint'])
 


### PR DESCRIPTION
This PR resolves issue #15.

How to test?

* Use MSAL Python 0.1.0. Start fiddler. Add a `verify=False` flag in any of the samples. Run it. You won't be able to complete a sample run due to the library complaining (this is essentially a Man-in-the-middle attack).

* You can test this PR by:

      pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@full-support-for-verify-and-proxies

* Rerun the previous test. This time you will successfully obtain a token (despite some warning message emitted from underlying library).