### PR TITLE
Adjusting token cache format

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -56,9 +56,9 @@ class TokenCache(object):
             default=str,  # A workaround when assertion is in bytes in Python 3
             ))
         response = event.get("response", {})
-        access_token = response.get("access_token", {})
-        refresh_token = response.get("refresh_token", {})
-        id_token = response.get("id_token", {})
+        access_token = response.get("access_token")
+        refresh_token = response.get("refresh_token")
+        id_token = response.get("id_token")
         client_info = {}
         home_account_id = None
         if "client_info" in response:
@@ -169,7 +169,8 @@ class TokenCache(object):
     def update_rt(self, rt_item, new_rt):
         key = self._build_rt_key(**rt_item)
         with self._lock:
-            rt = self._cache.setdefault(self.CredentialType.REFRESH_TOKEN, {})[key]
+            RTs = self._cache.setdefault(self.CredentialType.REFRESH_TOKEN, {})
+            rt = RTs.get(key, {})  # key usually exists, but we'll survive its absence
             rt["secret"] = new_rt
 
 

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -50,7 +50,7 @@ class TokenCache(object):
 		    if target else True)
                 ]
 
-    def add(self, event):
+    def add(self, event, now=None):
         # type: (dict) -> None
         # event typically contains: client_id, scope, token_endpoint,
         # resposne, params, data, grant_type
@@ -86,7 +86,7 @@ class TokenCache(object):
                     realm or "",
 		    target,
                     ]).lower()
-                now = time.time()
+                now = time.time() if now is None else now
                 self._cache.setdefault(self.CredentialType.ACCESS_TOKEN, {})[key] = {
                     "credential_type": self.CredentialType.ACCESS_TOKEN,
                     "secret": access_token,
@@ -202,8 +202,8 @@ class SerializableTokenCache(TokenCache):
         Indicates whether the cache state has changed since last
         :func:`~serialize` or :func:`~deserialize` call.
     """
-    def add(self, event):
-        super(SerializableTokenCache, self).add(event)
+    def add(self, event, **kwargs):
+        super(SerializableTokenCache, self).add(event, **kwargs)
         self.has_state_changed = True
 
     def remove_rt(self, rt_item):

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -116,6 +116,7 @@ class TokenCache(object):
                         "oid", decoded_id_token.get("sub")),
                     "username": decoded_id_token.get("preferred_username"),
                     "authority_type": "AAD",  # Always AAD?
+                    # "client_info": response.get("client_info"),  # Optional
                     }
 
             if id_token:
@@ -146,9 +147,7 @@ class TokenCache(object):
                     "home_account_id": home_account_id,
                     "environment": environment,
                     "client_id": event.get("client_id"),
-                    # Fields below are considered optional
-                    "target": target,
-                    "client_info": response.get("client_info"),
+                    "target": target,  # Optional per schema though
                     }
                 if "foci" in response:
                     rt["family_id"] = response["foci"]

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -231,5 +231,5 @@ class SerializableTokenCache(TokenCache):
         """Serialize the current cache state into a string."""
         with self._lock:
             self.has_state_changed = False
-            return json.dumps(self._cache)
+            return json.dumps(self._cache, indent=4)
 

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -115,7 +115,9 @@ class TokenCache(object):
                     "local_account_id": decoded_id_token.get(
                         "oid", decoded_id_token.get("sub")),
                     "username": decoded_id_token.get("preferred_username"),
-                    "authority_type": "AAD",  # Always AAD?
+                    "authority_type":
+                        "ADFS" if realm == "adfs"
+                        else "MSSTS",  # MSSTS means AAD v2 for both AAD & MSA
                     # "client_info": response.get("client_info"),  # Optional
                     }
 
@@ -126,6 +128,7 @@ class TokenCache(object):
                     self.CredentialType.ID_TOKEN,
                     event.get("client_id", ""),
                     realm or "",
+                    ""  # Albeit irrelevant, schema requires an empty scope here
                     ]).lower()
                 self._cache.setdefault(self.CredentialType.ID_TOKEN, {})[key] = {
                     "credential_type": self.CredentialType.ID_TOKEN,
@@ -164,7 +167,7 @@ class TokenCache(object):
             cls.CredentialType.REFRESH_TOKEN,
             client_id or "",
             "",  # RT is cross-tenant in AAD
-	    target,
+	    target or "",  # raw value could be None if deserialized from other SDK
             ]).lower()
 
     def remove_rt(self, rt_item):

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -87,6 +87,7 @@ class TokenCache(object):
 		    target,
                     ]).lower()
                 now = time.time() if now is None else now
+                expires_in = response.get("expires_in", 3599)
                 self._cache.setdefault(self.CredentialType.ACCESS_TOKEN, {})[key] = {
                     "credential_type": self.CredentialType.ACCESS_TOKEN,
                     "secret": access_token,
@@ -95,9 +96,10 @@ class TokenCache(object):
                     "client_id": event.get("client_id"),
                     "target": target,
                     "realm": realm,
-                    "cached_at": now,
-                    "expires_on": now + response.get("expires_in", 3599),
-                    "extended_expires_on": now + response.get("ext_expires_in", 0),
+                    "cached_at": str(int(now)),  # Schema defines it as a string
+                    "expires_on": str(int(now + expires_in)),  # Same here
+                    "extended_expires_on": str(int(  # Same here
+                        now + response.get("ext_expires_in", expires_in))),
                     }
 
             if client_info:

--- a/sample/client_credential_sample.py
+++ b/sample/client_credential_sample.py
@@ -30,7 +30,8 @@ app = msal.ConfidentialClientApplication(
     config["client_id"], authority=config["authority"],
     client_credential=config["secret"],
     # token_cache=...  # Default cache is in memory only.
-                       # See SerializableTokenCache for more details.
+                       # You can learn how to use SerializableTokenCache from
+                       # https://msal-python.rtfd.io/en/latest/#msal.SerializableTokenCache
     )
 
 # The pattern to acquire a token looks like this.
@@ -42,7 +43,7 @@ result = None
 result = app.acquire_token_silent(config["scope"], account=None)
 
 if not result:
-    # So no suitable token exists in cache. Let's get a new one from AAD.
+    logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
     result = app.acquire_token_for_client(scopes=config["scope"])
 
 if "access_token" in result:

--- a/sample/device_flow_sample.py
+++ b/sample/device_flow_sample.py
@@ -4,7 +4,7 @@ The configuration file would look like this:
 {
     "authority": "https://login.microsoftonline.com/organizations",
     "client_id": "your_client_id",
-    "scope": ["user.read"]
+    "scope": ["User.Read"]
 }
 
 You can then run this sample with a JSON configuration file:
@@ -28,7 +28,8 @@ config = json.load(open(sys.argv[1]))
 app = msal.PublicClientApplication(
     config["client_id"], authority=config["authority"],
     # token_cache=...  # Default cache is in memory only.
-                       # See SerializableTokenCache for more details.
+                       # You can learn how to use SerializableTokenCache from
+                       # https://msal-python.rtfd.io/en/latest/#msal.SerializableTokenCache
     )
 
 # The pattern to acquire a token looks like this.
@@ -39,7 +40,7 @@ result = None
 # We now check the cache to see if we have some end users signed in before.
 accounts = app.get_accounts()
 if accounts:
-    # If so, you could then somehow display these accounts and let end user choose
+    logging.info("Account(s) exists in cache, probably with token too. Let's try.")
     print("Pick the account you want to use to proceed:")
     for a in accounts:
         print(a["username"])
@@ -49,7 +50,7 @@ if accounts:
     result = app.acquire_token_silent(config["scope"], account=chosen)
 
 if not result:
-    # So no suitable token exists in cache. Let's get a new one from AAD.
+    logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
     flow = app.initiate_device_flow(scopes=config["scope"])
     print(flow["message"])
     # Ideally you should wait here, in order to save some unnecessary polling

--- a/sample/username_password_sample.py
+++ b/sample/username_password_sample.py
@@ -5,7 +5,7 @@ The configuration file would look like this:
     "authority": "https://login.microsoftonline.com/organizations",
     "client_id": "your_client_id",
     "username": "your_username@your_tenant.com",
-    "scope": ["user.read"],
+    "scope": ["User.Read"],
     "password": "This is a sample only. You better NOT persist your password."
 }
 
@@ -30,7 +30,8 @@ config = json.load(open(sys.argv[1]))
 app = msal.PublicClientApplication(
     config["client_id"], authority=config["authority"],
     # token_cache=...  # Default cache is in memory only.
-                       # See SerializableTokenCache for more details.
+                       # You can learn how to use SerializableTokenCache from
+                       # https://msal-python.rtfd.io/en/latest/#msal.SerializableTokenCache
     )
 
 # The pattern to acquire a token looks like this.
@@ -39,11 +40,11 @@ result = None
 # Firstly, check the cache to see if this end user has signed in before
 accounts = app.get_accounts(username=config["username"])
 if accounts:
-    # It means the account(s) exists in cache, probably with token too. Let's try.
+    logging.info("Account(s) exists in cache, probably with token too. Let's try.")
     result = app.acquire_token_silent(config["scope"], account=accounts[0])
 
 if not result:
-    # So no suitable token exists in cache. Let's get a new one from AAD.
+    logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
     result = app.acquire_token_by_username_password(
         config["username"], config["password"], scopes=config["scope"])
 

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -1,0 +1,119 @@
+import logging
+import base64
+import json
+
+from msal.token_cache import *
+from tests import unittest
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+class TokenCacheTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.cache = TokenCache()
+
+    def testAdd(self):
+        client_info = base64.b64encode(b'''
+            {"uid": "uid", "utid": "utid"}
+            ''').decode('utf-8')
+        id_token = "header.%s.signature" % base64.b64encode(b'''{
+            "sub": "subject",
+            "oid": "object1234",
+            "preferred_username": "John Doe"
+            }''').decode('utf-8')
+        self.cache.add({
+            "client_id": "my_client_id",
+            "scope": ["s2", "s1", "s3"],  # Not in particular order
+            "token_endpoint": "https://login.example.com/contoso/v2/token",
+            "response": {
+		"access_token": "an access token",
+		"token_type": "some type",
+		"expires_in": 3600,
+		"refresh_token": "a refresh token",
+                "client_info": client_info,
+                "id_token": id_token,
+		},
+            }, now=1000)
+        self.assertEqual(
+            {
+                'cached_at': 1000,
+                'client_id': 'my_client_id',
+                'credential_type': 'AccessToken',
+                'environment': 'login.example.com',
+                'expires_on': 4600,
+                'extended_expires_on': 1000,
+                'home_account_id': "uid.utid",
+                'realm': 'contoso',
+                'secret': 'an access token',
+                'target': 's2 s1 s3',
+            },
+            self.cache._cache["AccessToken"].get(
+                'uid.utid-login.example.com-accesstoken-my_client_id-contoso-s2 s1 s3')
+            )
+        self.assertEqual(
+            {
+                'client_id': 'my_client_id',
+                'credential_type': 'RefreshToken',
+                'environment': 'login.example.com',
+                'home_account_id': "uid.utid",
+                'secret': 'a refresh token',
+                'target': 's2 s1 s3',
+            },
+            self.cache._cache["RefreshToken"].get(
+                'uid.utid-login.example.com-refreshtoken-my_client_id--s2 s1 s3')
+            )
+        self.assertEqual(
+            {
+                'home_account_id': "uid.utid",
+                'environment': 'login.example.com',
+                'realm': 'contoso',
+                'local_account_id': "object1234",
+                'username': "John Doe",
+                'authority_type': "AAD",
+            },
+            self.cache._cache["Account"].get('uid.utid-login.example.com-contoso')
+            )
+        self.assertEqual(
+            {
+                'credential_type': 'IdToken',
+                'secret': id_token,
+                'home_account_id': "uid.utid",
+                'environment': 'login.example.com',
+                'realm': 'contoso',
+                'client_id': 'my_client_id',
+            },
+            self.cache._cache["IdToken"].get(
+                'uid.utid-login.example.com-idtoken-my_client_id-contoso')
+            )
+
+
+class SerializableTokenCacheTestCase(TokenCacheTestCase):
+    # Run all inherited test methods, and have extra check in tearDown()
+
+    def setUp(self):
+        self.cache = SerializableTokenCache()
+        self.cache.deserialize("""
+            {
+                "AccessToken": {
+                    "an-entry": {
+                        "foo": "bar"
+                        }
+                    },
+                "customized": "whatever"
+            }
+            """)
+
+    def tearDown(self):
+        state = self.cache.serialize()
+        logger.debug("serialize() = %s", state)
+        # Now assert all extended content are kept intact
+        output = json.loads(state)
+        self.assertEqual(output.get("customized"), "whatever",
+            "Undefined cache keys and their values should be intact")
+        self.assertEqual(
+            output.get("AccessToken", {}).get("an-entry"), {"foo": "bar"},
+            "Undefined token keys and their values should be intact")
+

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -72,7 +72,7 @@ class TokenCacheTestCase(unittest.TestCase):
                 'realm': 'contoso',
                 'local_account_id': "object1234",
                 'username': "John Doe",
-                'authority_type': "AAD",
+                'authority_type': "MSSTS",
             },
             self.cache._cache["Account"].get('uid.utid-login.example.com-contoso')
             )
@@ -86,7 +86,7 @@ class TokenCacheTestCase(unittest.TestCase):
                 'client_id': 'my_client_id',
             },
             self.cache._cache["IdToken"].get(
-                'uid.utid-login.example.com-idtoken-my_client_id-contoso')
+                'uid.utid-login.example.com-idtoken-my_client_id-contoso-')
             )
 
 

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -39,12 +39,12 @@ class TokenCacheTestCase(unittest.TestCase):
             }, now=1000)
         self.assertEqual(
             {
-                'cached_at': 1000,
+                'cached_at': "1000",
                 'client_id': 'my_client_id',
                 'credential_type': 'AccessToken',
                 'environment': 'login.example.com',
-                'expires_on': 4600,
-                'extended_expires_on': 1000,
+                'expires_on': "4600",
+                'extended_expires_on': "4600",
                 'home_account_id': "uid.utid",
                 'realm': 'contoso',
                 'secret': 'an access token',


### PR DESCRIPTION
* Change scope's internal representation from a list to a string
* Remove client_info from RefreshToken because it was optional and now obsolete
* Add test case to ensure the token cache representation complies with the Unified Schema
* The existing token cache implementation is already extendable, we only need to add a test case to assert that.

You can install this branch for your testing:

    pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@target-in-string
