### PR TITLE
Fix bug of cache.has_state_changed not being initialized

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -207,6 +207,8 @@ class SerializableTokenCache(TokenCache):
         Indicates whether the cache state has changed since last
         :func:`~serialize` or :func:`~deserialize` call.
     """
+    has_state_changed = False
+
     def add(self, event, **kwargs):
         super(SerializableTokenCache, self).add(event, **kwargs)
         self.has_state_changed = True

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -106,6 +106,12 @@ class SerializableTokenCacheTestCase(TokenCacheTestCase):
             }
             """)
 
+    def test_has_state_changed(self):
+        cache = SerializableTokenCache()
+        self.assertFalse(cache.has_state_changed)
+        cache.add({})  # An NO-OP add() still counts as a state change. Good enough.
+        self.assertTrue(cache.has_state_changed)
+
     def tearDown(self):
         state = self.cache.serialize()
         logger.debug("serialize() = %s", state)


### PR DESCRIPTION
This fixes one of the issues we found in yesterday's testing session. @MarkZuber @abhidnya13 