### PR TITLE
Make msal namespace extensible

### DIFF
--- a/msal/__init__.py
+++ b/msal/__init__.py
@@ -24,6 +24,7 @@
 # THE SOFTWARE.
 #
 #------------------------------------------------------------------------------
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 from .application import (
     __version__,


### PR DESCRIPTION
Developing [marstr/microsoft-authentication-extensions-for-python](https://github.com/marstr/microsoft-authentication-extensions-for-python), I came to realize that I was unable to extend the `msal` namespace. The result was a weird situation where the extensions library would need to be installed first. This change will allow these two distributions to be installed side-by-side in the same way the .NET packages can be.