### PR TITLE
Add remove_account() API

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -174,8 +174,9 @@ class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
         self.account = {"home_account_id": "{}.{}".format(self.uid, self.utid)}
         self.frt = "what the frt"
         self.cache = msal.SerializableTokenCache()
+        self.preexisting_family_app_id = "preexisting_family_app"
         self.cache.add({  # Pre-populate a FRT
-            "client_id": "preexisting_family_app",
+            "client_id": self.preexisting_family_app_id,
             "scope": self.scopes,
             "token_endpoint": "{}/oauth2/v2.0/token".format(self.authority_url),
             "response": TokenCacheTestCase.build_response(
@@ -241,10 +242,11 @@ class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
 
     # Will not test scenario of app leaving family. Per specs, it won't happen.
 
-    def test_get_remove_account(self):
+    def test_family_app_remove_account(self):
         logger.debug("%s.cache = %s", self.id(), self.cache.serialize())
         app = ClientApplication(
-            "family_app_2", authority=self.authority_url, token_cache=self.cache)
+            self.preexisting_family_app_id,
+            authority=self.authority_url, token_cache=self.cache)
         account = app.get_accounts()[0]
         mine = {"home_account_id": account["home_account_id"]}
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -179,6 +179,8 @@ class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
             "scope": self.scopes,
             "token_endpoint": "{}/oauth2/v2.0/token".format(self.authority_url),
             "response": TokenCacheTestCase.build_response(
+                access_token="Siblings won't share AT. test_remove_account() will.",
+                id_token=TokenCacheTestCase.build_id_token(),
                 uid=self.uid, utid=self.utid, refresh_token=self.frt, foci="1"),
             })  # The add(...) helper populates correct home_account_id for future searching
 
@@ -238,6 +240,34 @@ class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
     # Known family app will simply use FRT, which is largely the same as this one
 
     # Will not test scenario of app leaving family. Per specs, it won't happen.
+
+    def test_get_remove_account(self):
+        logger.debug("%s.cache = %s", self.id(), self.cache.serialize())
+        app = ClientApplication(
+            "family_app_2", authority=self.authority_url, token_cache=self.cache)
+        account = app.get_accounts()[0]
+        mine = {"home_account_id": account["home_account_id"]}
+
+        self.assertNotEqual([], self.cache.find(
+            self.cache.CredentialType.ACCESS_TOKEN, query=mine))
+        self.assertNotEqual([], self.cache.find(
+            self.cache.CredentialType.REFRESH_TOKEN, query=mine))
+        self.assertNotEqual([], self.cache.find(
+            self.cache.CredentialType.ID_TOKEN, query=mine))
+        self.assertNotEqual([], self.cache.find(
+            self.cache.CredentialType.ACCOUNT, query=mine))
+
+        app.remove_account(account)
+
+        self.assertEqual([], self.cache.find(
+            self.cache.CredentialType.ACCESS_TOKEN, query=mine))
+        self.assertEqual([], self.cache.find(
+            self.cache.CredentialType.REFRESH_TOKEN, query=mine))
+        self.assertEqual([], self.cache.find(
+            self.cache.CredentialType.ID_TOKEN, query=mine))
+        self.assertEqual([], self.cache.find(
+            self.cache.CredentialType.ACCOUNT, query=mine))
+
 
 class TestClientApplicationForAuthorityMigration(unittest.TestCase):
 


### PR DESCRIPTION
Add remove_account() API, and it will signout the account from the app family. This PR will close #12 .

Most of the implementations are refactoring the underlying cache helpers. To review high level "what does it do" logic, please focus on only 50 lines starting from [here](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/41/files#diff-f7ae931bcdab4b14f3a256baf7d6922aR283) (half of them are inline documentation).