### PR TITLE
Avoid hardcoding secret

### DIFF
--- a/sample/authorization-code-flow-sample/authorization_code_flow_sample.py
+++ b/sample/authorization-code-flow-sample/authorization_code_flow_sample.py
@@ -29,7 +29,7 @@ import msal
 
 app = flask.Flask(__name__)
 app.debug = True
-app.secret_key = 'development'
+app.secret_key = sys.argv[2]  # In this demo, we expect a secret from 2nd CLI param
 
 
 # Optional logging

--- a/sample/authorization-code-flow-sample/authorization_code_flow_sample.py
+++ b/sample/authorization-code-flow-sample/authorization_code_flow_sample.py
@@ -13,8 +13,10 @@ The configuration file would look like this:
 }
 
 You can then run this sample with a JSON configuration file:
-    python sample.py parameters.json
-    On the browser open http://localhost:5000/
+
+    python sample.py parameters.json your_flask_session_secret_here
+
+And the on the browser open http://localhost:5000/
 
 """
 


### PR DESCRIPTION
Even this is just a sample app, not our production library code, we are still making this improvement as precaution.
In such flask-based sample, a secret key is needed for its session feature to function. [Flask's own official documentation does it all the time](http://flask.pocoo.org/docs/1.0/quickstart/#sessions).
Nonetheless, we now avoid hardcoding secret, not even a placeholder.