### PR TITLE
Do not write null into family_id

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -158,11 +158,13 @@ class TokenCache(object):
                 self._cache.setdefault(self.CredentialType.REFRESH_TOKEN, {})[key] = rt
 
             key = self._build_appmetadata_key(environment, event.get("client_id"))
-            self._cache.setdefault(self.CredentialType.APP_METADATA, {})[key] = {
+            app_metadata = {
                 "client_id": event.get("client_id"),
                 "environment": environment,
-                "family_id": response.get("foci"),  # None is also valid
                 }
+            if "foci" in response:
+                app_metadata["family_id"] = response.get("foci")
+            self._cache.setdefault(self.CredentialType.APP_METADATA, {})[key] = app_metadata
 
     def modify(self, credential_type, old_entry, new_key_value_pairs=None):
         # Modify the specified old_entry with new_key_value_pairs,

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -119,7 +119,6 @@ class TokenCacheTestCase(unittest.TestCase):
             {
                 "client_id": "my_client_id",
                 'environment': 'login.example.com',
-                "family_id": None,
             },
             self.cache._cache.get("AppMetadata", {}).get(
                 "appmetadata-login.example.com-my_client_id")


### PR DESCRIPTION
In this PR, we adjust to not write null into token cache. Relevant test case is also updated.