### PR TITLE
Handle string time values when caching responses

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -128,9 +128,11 @@ class TokenCache(object):
         with self._lock:
 
             if access_token:
-                now = int(time.time()) if now is None else int(now)
-                expires_in = int(response.get("expires_in", 3599))
-                ext_expires_in = int(response.get("ext_expires_in", expires_in))
+                now = int(time.time() if now is None else now)
+                expires_in = int(  # AADv1-like endpoint returns a string
+			response.get("expires_in", 3599))
+                ext_expires_in = int(  # AADv1-like endpoint returns a string
+			response.get("ext_expires_in", expires_in))
                 at = {
                     "credential_type": self.CredentialType.ACCESS_TOKEN,
                     "secret": access_token,

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -1,4 +1,4 @@
-﻿import json
+import json
 import threading
 import time
 import logging
@@ -128,8 +128,9 @@ class TokenCache(object):
         with self._lock:
 
             if access_token:
-                now = time.time() if now is None else now
-                expires_in = response.get("expires_in", 3599)
+                now = int(time.time()) if now is None else int(now)
+                expires_in = int(response.get("expires_in", 3599))
+                ext_expires_in = int(response.get("ext_expires_in", expires_in))
                 at = {
                     "credential_type": self.CredentialType.ACCESS_TOKEN,
                     "secret": access_token,
@@ -138,10 +139,9 @@ class TokenCache(object):
                     "client_id": event.get("client_id"),
                     "target": target,
                     "realm": realm,
-                    "cached_at": str(int(now)),  # Schema defines it as a string
-                    "expires_on": str(int(now + expires_in)),  # Same here
-                    "extended_expires_on": str(int(  # Same here
-                        now + response.get("ext_expires_in", expires_in))),
+                    "cached_at": str(now),  # Schema defines it as a string
+                    "expires_on": str(now + expires_in),  # Same here
+                    "extended_expires_on": str(now + ext_expires_in)  # Same here
                     }
                 self.modify(self.CredentialType.ACCESS_TOKEN, at, at)
 

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -1,4 +1,4 @@
-import json
+﻿import json
 import threading
 import time
 import logging
@@ -54,7 +54,7 @@ class TokenCache(object):
                         home_account_id or "",
                         environment or "",
                         self.CredentialType.ACCESS_TOKEN,
-                        client_id,
+                        client_id or "",
                         realm or "",
                         target or "",
                         ]).lower(),


### PR DESCRIPTION
If `response["expires_in"]` is a string--as is the case for [Azure Instance Metadata Service](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http) auth responses--lines 142 and 144 will raise because strings and integers can't be added. This change ensures all addends (`now`, `expires_in`, `ext_expires_in`) are integers.

This also fixes an issue with the access token key maker. It accepts an optional `client_id` but when this is unspecified, the key maker passes `None` to `str.join`, which raises. I changed this to pass the empty string instead, as do other key makers.