### PR TITLE
Support sovereign cloud.

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -1,10 +1,12 @@
 import re
+import logging
 
 import requests
 
 from .exceptions import MsalServiceError
 
 
+logger = logging.getLogger(__name__)
 WORLD_WIDE = 'login.microsoftonline.com'  # There was an alias login.windows.net
 WELL_KNOWN_AUTHORITY_HOSTS = set([
     WORLD_WIDE,
@@ -38,7 +40,7 @@ class Authority(object):
         canonicalized, self.instance, tenant = canonicalize(authority_url)
         tenant_discovery_endpoint = (  # Hard code a V2 pattern as default value
             'https://{}/{}/v2.0/.well-known/openid-configuration'
-            .format(WORLD_WIDE, tenant))
+            .format(self.instance, tenant))
         if validate_authority and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS:
             tenant_discovery_endpoint = instance_discovery(
                 canonicalized + "/oauth2/v2.0/authorize",
@@ -46,6 +48,7 @@ class Authority(object):
         openid_config = tenant_discovery(
             tenant_discovery_endpoint,
             verify=verify, proxies=proxies, timeout=timeout)
+        logger.debug("openid_config = %s", openid_config)
         self.authorization_endpoint = openid_config['authorization_endpoint']
         self.token_endpoint = openid_config['token_endpoint']
         _, _, self.tenant = canonicalize(self.token_endpoint)  # Usually a GUID
@@ -76,7 +79,11 @@ def canonicalize(url):
 def instance_discovery(url, response=None, **kwargs):
     # Returns tenant discovery endpoint
     resp = requests.get(  # Note: This URL seemingly returns V1 endpoint only
-        'https://{}/common/discovery/instance'.format(WORLD_WIDE),
+        'https://{}/common/discovery/instance'.format(
+            WORLD_WIDE  # Historically using WORLD_WIDE. Could use self.instance too
+                # See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.0.0/src/Microsoft.Identity.Client/Instance/AadInstanceDiscovery.cs#L101-L103
+                # and https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.0.0/src/Microsoft.Identity.Client/Instance/AadAuthority.cs#L19-L33
+            ),
         params={'authorization_endpoint': url, 'api-version': '1.0'},
         **kwargs)
     payload = response or resp.json()


### PR DESCRIPTION
[Previous implementation](https://github.com/AzureAD/microsoft-authentication-library-for-python/blame/dev/msal/authority.py#L41) was based on some hallway communication 3 years ago. Sovereign scenario was not brought up at that time, and such implementation happened to not work in sovereign scenarios.

PS: ADAL Python happened to use a different implementation which was not susceptible to this issue.

The actual fix is just a [one-liner](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/62/files#diff-cb217807c4296437af63bf4a2954b7b7R43). The rest are refactoring, notes and test cases adjustments.
@yugangw-msft , would you mind to test it by pulling it from this branch?

    pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@sovereign-support

Once tested and merged, this PR will fix #59 .