### PR TITLE
Change an optional scopes parameter to be required

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -512,7 +512,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
                 **kwargs)
 
     def acquire_token_by_username_password(
-            self, username, password, scopes=None, **kwargs):
+            self, username, password, scopes, **kwargs):
         """Gets a token for a given resource via user credentails.
 
         See this page for constraints of Username Password Flow.


### PR DESCRIPTION
Discovered in PR #61 's second finding (thank you Jann!), the previous default None value in `acquire_token_by_username_password(..., scopes=None)` would cause an exception in our internal helper `decorate_scope()`.

The fix is to change the previously optional scopes parameter to required.
This kind of api surface change would usually be a breaking change, but in this case it is not,
because the previous default value would cause exception so it was in fact required.

FWIW, you can still explicitly use empty list `[]` as scope,
and the response would contain id_token and refresh_token, but no access_token.