### PR TITLE
ConfidentialClient with extra claims

### DIFF
--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -1,0 +1,15 @@
+import json
+
+from msal.oauth2cli import JwtSigner
+from msal.oauth2cli.oidc import base64decode
+
+from tests import unittest
+
+
+class AssertionTestCase(unittest.TestCase):
+    def test_extra_claims(self):
+        assertion = JwtSigner(key=None, algorithm="none").sign_assertion(
+            "audience", "issuer", additional_claims={"client_ip": "1.2.3.4"})
+        payload = json.loads(base64decode(assertion.split(b'.')[1].decode('utf-8')))
+        self.assertEqual("1.2.3.4", payload.get("client_ip"))
+


### PR DESCRIPTION
This ~is a proof-of-concept in attempt to~ resolve #67.

~It has NOT been tested at this time.~ A unit test case is added.

Please also help proof-read [the documentation](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/68/files#diff-f7ae931bcdab4b14f3a256baf7d6922aR75), which will automatically be published into our [online reference doc](https://msal-python.readthedocs.io/en/latest/#msal.ClientApplication.__init__) once this PR is merged.

@trwalke You do not have to look into the actual implementation, but please help double check with the [API surface](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/68/files#diff-f7ae931bcdab4b14f3a256baf7d6922aR96) and then [the new claim(s) would be sent inside client assertion (rather than, say, as a user assertion like OBO)](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/68/files#diff-f7ae931bcdab4b14f3a256baf7d6922aR160) are aligned with our feature requirement.