### PR TITLE
Subject Name and Issuer Authentication

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -110,22 +110,17 @@ class ClientApplication(object):
         client_assertion = None
         client_assertion_type = None
         default_body = {"client_info": 1}
+        headers = {}
         if isinstance(client_credential, dict):
             assert ("private_key" in client_credential
                     and "thumbprint" in client_credential)
             if 'public_certificate' in client_credential:
-                if isinstance(client_credential['public_certificate'], list):
-                    public_certificate = client_credential['public_certificate']
-                else:
-                    public_certificate = [client_credential['public_certificate']]
-                signer = JwtSigner(
-                    client_credential["private_key"], algorithm="RS256",
-                    sha1_thumbprint=client_credential.get("thumbprint"),
-                    headers={"x5c": public_certificate})
-            else:
-                signer = JwtSigner(
-                    client_credential["private_key"], algorithm="RS256",
-                    sha1_thumbprint=client_credential.get("thumbprint"))
+                headers["x5c"] = client_credential['public_certificate'] \
+                    if isinstance(client_credential['public_certificate'], list) \
+                    else [client_credential['public_certificate']]  # We send x5c as a list of strings
+            signer = JwtSigner(
+                client_credential["private_key"], algorithm="RS256",
+                sha1_thumbprint=client_credential.get("thumbprint"), headers=headers)
             client_assertion = signer.sign_assertion(
                 audience=authority.token_endpoint, issuer=self.client_id)
             client_assertion_type = Client.CLIENT_ASSERTION_TYPE_JWT

--- a/msal/application.py
+++ b/msal/application.py
@@ -109,13 +109,15 @@ class ClientApplication(object):
     def _build_client(self, client_credential, authority):
         client_assertion = None
         client_assertion_type = None
+        public_certificate = None
         default_body = {"client_info": 1}
         if isinstance(client_credential, dict):
             assert ("private_key" in client_credential
                     and "thumbprint" in client_credential)
             signer = JwtSigner(
                 client_credential["private_key"], algorithm="RS256",
-                sha1_thumbprint=client_credential.get("thumbprint"))
+                sha1_thumbprint=client_credential.get("thumbprint"),
+                public_certificate = client_credential['public_certificate'])
             client_assertion = signer.sign_assertion(
                 audience=authority.token_endpoint, issuer=self.client_id)
             client_assertion_type = Client.CLIENT_ASSERTION_TYPE_JWT

--- a/msal/application.py
+++ b/msal/application.py
@@ -54,10 +54,15 @@ def extract_certs(public_cert_content):
     # Parses raw public certificate file contents and returns a list of strings
     # Usage: headers = {"x5c": extract_certs(open("my_cert.pem").read())}
     public_certificates = re.findall(
-        r'\-+BEGIN CERTIFICATE.+\-+(?P<cert_value>[^-]+)\-+END CERTIFICATE.+\-+',
+        r'-----BEGIN CERTIFICATE-----(?P<cert_value>[^-]+)-----END CERTIFICATE-----',
         public_cert_content, re.I)
-    if len(public_certificates):
+    if public_certificates:
         return [cert.strip() for cert in public_certificates]
+    # The public cert tags are not found in the input,
+    # let's make best effort to exclude a private key pem file.
+    if "PRIVATE KEY" in public_cert_content:
+        raise ValueError(
+            "We expect your public key but detect a private key instead")
     return [public_cert_content.strip()]
 
 

--- a/msal/oauth2cli/assertion.py
+++ b/msal/oauth2cli/assertion.py
@@ -18,7 +18,7 @@ class Signer(object):
 
 
 class JwtSigner(Signer):
-    def __init__(self, key, algorithm, sha1_thumbprint=None, headers=None, public_certificate= None):
+    def __init__(self, key, algorithm, sha1_thumbprint=None, headers=None):
         """Create a signer.
 
         Args:
@@ -36,8 +36,6 @@ class JwtSigner(Signer):
         if sha1_thumbprint:  # https://tools.ietf.org/html/rfc7515#section-4.1.7
             self.headers["x5t"] = base64.urlsafe_b64encode(
                 binascii.a2b_hex(sha1_thumbprint)).decode()
-        if public_certificate:
-            self.headers['x5c'] = public_certificate
 
     def sign_assertion(
             self, audience, issuer, subject=None, expires_at=None,

--- a/msal/oauth2cli/assertion.py
+++ b/msal/oauth2cli/assertion.py
@@ -18,7 +18,7 @@ class Signer(object):
 
 
 class JwtSigner(Signer):
-    def __init__(self, key, algorithm, sha1_thumbprint=None, headers=None):
+    def __init__(self, key, algorithm, sha1_thumbprint=None, headers=None, public_certificate= None):
         """Create a signer.
 
         Args:
@@ -36,6 +36,8 @@ class JwtSigner(Signer):
         if sha1_thumbprint:  # https://tools.ietf.org/html/rfc7515#section-4.1.7
             self.headers["x5t"] = base64.urlsafe_b64encode(
                 binascii.a2b_hex(sha1_thumbprint)).decode()
+        if public_certificate:
+            self.headers['x5c'] = public_certificate
 
     def sign_assertion(
             self, audience, issuer, subject=None, expires_at=None,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -99,6 +99,76 @@ class TestConfidentialClientApplication(unittest.TestCase):
         self.assertIn('access_token', result)
         self.assertCacheWorks(result, app.acquire_token_silent(scope, account=None))
 
+    @unittest.skipUnless("public_certificate" in CONFIG, "Missing Public cert")
+    def test_subject_name_issuer_authentication_input_with_begin_certificate_and_end_certificate_single(self):
+        assert ("private_key_file" in CONFIG
+                and "thumbprint" in CONFIG and "public_certificate" in CONFIG)
+        key_path = os.path.join(THIS_FOLDER, CONFIG['private_key_file'])
+        public_certificate = os.path.join(THIS_FOLDER, CONFIG['public_certificate'])
+        with open(key_path) as f:
+            pem = f.read()
+        with open(public_certificate) as f:
+            public_certificate = f.read()
+        app = ConfidentialClientApplication(
+            CONFIG['client_id'],
+            client_credential={"private_key": pem, "thumbprint": CONFIG["thumbprint"],
+                               "public_certificate": public_certificate})
+        x5c = app._extract_x5c_value()
+        self.assertIsInstance(x5c, list)
+        self.assertEquals(len(x5c), 1)
+
+    @unittest.skipUnless("public_certificate" in CONFIG, "Missing Public cert")
+    def test_subject_name_issuer_authentication_input_with_begin_certificate_and_end_certificate_multiple(self):
+        assert ("private_key_file" in CONFIG
+                and "thumbprint" in CONFIG and "public_certificate" in CONFIG)
+        key_path = os.path.join(THIS_FOLDER, CONFIG['private_key_file'])
+        public_certificate = os.path.join(THIS_FOLDER, CONFIG['public_certificate'])
+        with open(key_path) as f:
+            pem = f.read()
+        with open(public_certificate) as f:
+            public_certificate = f.read()
+        app = ConfidentialClientApplication(
+            CONFIG['client_id'],
+            {"private_key": pem, "thumbprint": CONFIG["thumbprint"], "public_certificate": public_certificate})
+        x5c = app._extract_x5c_value()
+        self.assertIsInstance(x5c, list)
+        self.assertGreater(len(x5c), 1)
+
+    @unittest.skipUnless("public_certificate" in CONFIG, "Missing Public cert")
+    def test_subject_name_issuer_authentication_input_without_begin_certificate_and_end_certificate(self):
+        assert ("private_key_file" in CONFIG
+                and "thumbprint" in CONFIG and "public_certificate" in CONFIG)
+        key_path = os.path.join(THIS_FOLDER, CONFIG['private_key_file'])
+        public_certificate = os.path.join(THIS_FOLDER, CONFIG['public_certificate'])
+        with open(key_path) as f:
+            pem = f.read()
+        with open(public_certificate) as f:
+            public_certificate = f.read()
+        app = ConfidentialClientApplication(
+            CONFIG['client_id'],
+            {"private_key": pem, "thumbprint": CONFIG["thumbprint"], "public_certificate": public_certificate})
+        x5c = app._extract_x5c_value()
+        self.assertIsInstance(x5c, list)
+        self.assertEquals(len(x5c), 1)
+
+    @unittest.skipUnless("public_certificate" in CONFIG, "Missing Public cert")
+    def test_subject_name_issuer_authentication(self):
+        assert ("private_key_file" in CONFIG
+                and "thumbprint" in CONFIG and "public_certificate" in CONFIG)
+        key_path = os.path.join(THIS_FOLDER, CONFIG['private_key_file'])
+        public_certificate = os.path.join(THIS_FOLDER, CONFIG['public_certificate'])
+        with open(key_path) as f:
+            pem = f.read()
+        with open(public_certificate) as f:
+            public_certificate = f.read()
+        app = ConfidentialClientApplication(
+            CONFIG['client_id'], authority=CONFIG["authority"],
+            client_credential={"private_key": pem, "thumbprint": CONFIG["thumbprint"],
+                               "public_certificate": public_certificate})
+        scope = CONFIG.get("scope", [])
+        result = app.acquire_token_for_client(scope)
+        self.assertIn('access_token', result)
+        self.assertCacheWorks(result, app.acquire_token_silent(scope, account=None))
 
 @unittest.skipUnless("client_id" in CONFIG, "client_id missing")
 class TestPublicClientApplication(Oauth2TestCase):


### PR DESCRIPTION
- This PR closes #60 
- Adds support for Subject Name Issuer Authentication which is to support cert auto rolls.
- We have tested the end to end scenario by creating our own Test Environment. We will work with the lab team for creating test environment and then integrating in Test automation.
- Note: 
This type of authentication expects authority url to be mentioned with the actual tenant id at the moment. Using organizations will fail the request