### PR TITLE
Pack LICENSE in a different way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'Operating System :: OS Independent',
     ],
     packages=find_packages(exclude=["tests"]),
-    data_files=[('', ['LICENSE'])],
+    package_data={'': ['LICENSE']},  # Do not use data_files=[...]. See https://stackoverflow.com/questions/14211575
     install_requires=[
         'requests>=2.0.0,<3',
         'PyJWT[crypto]>=1.0.0,<2',

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,10 @@ setup(
         'Operating System :: OS Independent',
     ],
     packages=find_packages(exclude=["tests"]),
-    package_data={'': ['LICENSE']},  # Do not use data_files=[...]. See https://stackoverflow.com/questions/14211575
+    package_data={'': ['LICENSE']},  # Do not use data_files=[...],
+        # which would cause the LICENSE being copied to /usr/local,
+        # and tend to fail because of insufficient permission.
+        # See https://stackoverflow.com/a/14211600/728675 for more detail
     install_requires=[
         'requests>=2.0.0,<3',
         'PyJWT[crypto]>=1.0.0,<2',


### PR DESCRIPTION
It turns out [the approach we used in PR #69](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/69#discussion_r296942855) would cause the LICENSE being copied into `/usr/local`, which would typically end up with insufficient permission error while some downstream build pipeline (such as, OSX) attempts to install msal without explicitly specifying `--user` option.

This PR uses a different to pack that LICENSE file and ship it inside this library's directory.