### PR TITLE
Release 0.5.1

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -18,7 +18,7 @@ from .token_cache import TokenCache
 
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,10 @@ setup(
         'Operating System :: OS Independent',
     ],
     packages=find_packages(exclude=["tests"]),
-    data_files=[('', ['LICENSE'])],
+    package_data={'': ['LICENSE']},  # Do not use data_files=[...],
+        # which would cause the LICENSE being copied to /usr/local,
+        # and tend to fail because of insufficient permission.
+        # See https://stackoverflow.com/a/14211600/728675 for more detail
     install_requires=[
         'requests>=2.0.0,<3',
         'PyJWT[crypto]>=1.0.0,<2',


### PR DESCRIPTION
* This release is functionally identical to 0.5.0. We are just fixing a packaging issue (#74) which would potentially cause some installation difficulty on a certain platform(s). If MSAL Python 0.5.0 is already working fine for you, you do not need to upgrade.