### PR TITLE
Use urlsafe_b64decode instead of b64decode

### DIFF
--- a/msal/oauth2cli/oidc.py
+++ b/msal/oauth2cli/oidc.py
@@ -8,6 +8,9 @@ from . import oauth2
 def base64decode(raw):
     """A helper can handle a padding-less raw input"""
     raw += '=' * (-len(raw) % 4)  # https://stackoverflow.com/a/32517907/728675
+    # On Python 2.7, argument of urlsafe_b64decode must be str, not unicode.
+    # This is not required on Python 3.
+    raw = str(raw)
     return base64.urlsafe_b64decode(raw).decode("utf-8")
 
 

--- a/msal/oauth2cli/oidc.py
+++ b/msal/oauth2cli/oidc.py
@@ -8,7 +8,7 @@ from . import oauth2
 def base64decode(raw):
     """A helper can handle a padding-less raw input"""
     raw += '=' * (-len(raw) % 4)  # https://stackoverflow.com/a/32517907/728675
-    return base64.b64decode(raw).decode("utf-8")
+    return base64.urlsafe_b64decode(raw).decode("utf-8")
 
 
 def decode_id_token(id_token, client_id=None, issuer=None, nonce=None, now=None):


### PR DESCRIPTION
- This PR fixes the error that occurs in decoding token.
- The ID token is encoded as base64url, not base64.
- In the previous implementation, [device_flow_sample.py](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/dev/sample/device_flow_sample.py) will fails with error `binascii.Error: Incorrect padding`.