### PR TITLE
The more generic common endpoint can now support Device Flow for MSA

### DIFF
--- a/sample/device_flow_sample.py
+++ b/sample/device_flow_sample.py
@@ -2,7 +2,7 @@
 The configuration file would look like this:
 
 {
-    "authority": "https://login.microsoftonline.com/organizations",
+    "authority": "https://login.microsoftonline.com/common",
     "client_id": "your_client_id",
     "scope": ["User.Read"]
 }


### PR DESCRIPTION
Since recently, the [Microsoft Identity platform supports Device Flow for personal accounts (MSA) too](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/728#issuecomment-527332063).

In this PR we adjust the comment, which is a mini-sample in its own to demonstrate "how to configure  this sample".

Manual test shows that:
* Using "common" endpoint can perform device flow to acquire a token for my corp account. So this change is at least as good as the previous "organizations" endpoint.
* Using "common" endpoint can also perform device flow for a Hotmail account. It seems the end user would need to type his/her password and redo the consent every time, though.