### PR TITLE
On-behalf-of (OBO) Implementation

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -646,10 +646,19 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
         representing an end user.
         The current app can use such token (a.k.a. a user assertion) to request
         another token to access downstream service, on behalf of that user.
+        See `detail docs here <https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>`_ .
 
         The current middle-tier app has no user interaction to obtain consent.
         See how to gain consent upfront for your middle-tier app from this article.
         https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#gaining-consent-for-the-middle-tier-application
+
+        :param str user_assertion: The incoming token already received by this app
+        :param list[str] scopes: Scopes required by downstream API (a resource).
+
+        :return: A dict representing the json response from AAD:
+
+            - A successful response would contain "access_token" key,
+            - an error response would contain "error" and usually "error_description".
         """
         # The implementation is NOT based on Token Exchange
         # https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16

--- a/msal/application.py
+++ b/msal/application.py
@@ -639,6 +639,17 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
                 scope=scopes,  # This grant flow requires no scope decoration
                 **kwargs)
 
-    def acquire_token_on_behalf_of(self, user_assertion, scopes, authority=None):
-        raise NotImplementedError()
+    def acquire_token_on_behalf_of(
+            self, user_assertion, scope, authority=None, policy=''):
+        the_authority = Authority(authority) if authority else self.authority
+        return oauth2.Client(
+            self.client_id, token_endpoint=the_authority.token_endpoint,
+            default_body=self._build_auth_parameters(
+                self.client_credential, the_authority.token_endpoint,
+                self.client_id)
+            )._get_token(  # TODO: Avoid using internal methods
+                "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                assertion=user_assertion, requested_token_use='on_behalf_of',
+                scope=scope,  # This grant flow requires no scope decoration???
+                query={'p': policy} if policy else None)
 

--- a/msal/application.py
+++ b/msal/application.py
@@ -656,9 +656,12 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
         return self.client.obtain_token_by_assertion(  # bases on assertion RFC 7521
             user_assertion,
             self.client.GRANT_TYPE_JWT,  # IDTs and AAD ATs are all JWTs
-            scope=scopes,  # Without decorate_scope(...), it still gets an AT.
-                # As of 2019, AAD would even issue RT, and ClientInfo i.e. account.
-                # No IDT will be issued. OBO app probably does not need one anyway.
+            scope=decorate_scope(scopes, self.client_id),  # Decoration is used for:
+                # 1. Explicitly requesting an RT, without relying on AAD default
+                #    behavior, even though it currently still issues an RT.
+                # 2. Requesting an IDT (which would otherwise be unavailable)
+                #    so that the calling app could use id_token_claims to implement
+                #    their own cache mapping, which is likely needed in web apps.
             data=dict(kwargs.pop("data", {}), requested_token_use="on_behalf_of"),
             **kwargs)
 

--- a/msal/application.py
+++ b/msal/application.py
@@ -642,10 +642,10 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
     def acquire_token_on_behalf_of(self, user_assertion, scopes, **kwargs):
         """Acquires token using on-behalf-of (OBO) flow.
 
-        The current app is a middle-tier service which already receives a token
+        The current app is a middle-tier service which was called with a token
         representing an end user.
         The current app can use such token (a.k.a. a user assertion) to request
-        another token to access downstream service, on behalf of that user.
+        another token to access downstream web API, on behalf of that user.
         See `detail docs here <https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow>`_ .
 
         The current middle-tier app has no user interaction to obtain consent.

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -194,3 +194,12 @@ class TestClientApplicationForAuthorityMigration(unittest.TestCase):
         self.assertNotEqual(None, at)
         self.assertEqual(self.access_token, at.get('access_token'))
 
+    def test_acquire_token_obo(self):
+        token = self.app.acquire_token_on_behalf_of(
+            self.token['access_token'], self.scope2)
+        error_description = token.get('error_description', "")
+        if 'grant is not supported by this API version' in error_description:
+            raise unittest.SkipTest(
+                "OBO is not yet supported by service: %s" % error_description)
+        self.assertEqual(error_description, "")
+

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -194,12 +194,3 @@ class TestClientApplicationForAuthorityMigration(unittest.TestCase):
         self.assertNotEqual(None, at)
         self.assertEqual(self.access_token, at.get('access_token'))
 
-    def test_acquire_token_obo(self):
-        token = self.app.acquire_token_on_behalf_of(
-            self.token['access_token'], self.scope2)
-        error_description = token.get('error_description', "")
-        if 'grant is not supported by this API version' in error_description:
-            raise unittest.SkipTest(
-                "OBO is not yet supported by service: %s" % error_description)
-        self.assertEqual(error_description, "")
-

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -330,30 +330,46 @@ class LabBasedTestCase(E2eTestCase):
     @unittest.skipUnless(
         os.getenv("OBO_CLIENT_SECRET"),
         "Need OBO_CLIENT_SECRET from https://buildautomation.vault.azure.net/secrets/IdentityDivisionDotNetOBOServiceSecret")
-    def test_acquire_token_obo(self):  # It hardcodes many pre-defined resources
+    def test_acquire_token_obo(self):
+        # Some hardcoded, pre-defined settings
         obo_client_id = "23c64cd8-21e4-41dd-9756-ab9e2c23f58c"
-        obo_scopes = ["https://graph.microsoft.com/User.Read"]
+        downstream_scopes = ["https://graph.microsoft.com/User.Read"]
         config = get_lab_user(isFederated=False)
+
+        # 1. An app obtains a token representing a user, for our mid-tier service
         pca = msal.PublicClientApplication(
             "be9b0186-7dfd-448a-a944-f771029105bf", authority=config.get("authority"))
         pca_result = pca.acquire_token_by_username_password(
             config["username"],
             self.get_lab_user_secret(config["lab"]["labname"]),
-            scopes=["%s/access_as_user" % obo_client_id],  # Need setup beforehand
+            scopes=[  # The OBO app's scope. Yours might be different.
+                "%s/access_as_user" % obo_client_id],
             )
-        self.assertNotEqual(None, pca_result.get("access_token"), "PCA should work")
+        self.assertIsNotNone(pca_result.get("access_token"), "PCA should work")
 
+        # 2. Our mid-tier service uses OBO to obtain a token for downstream service
         cca = msal.ConfidentialClientApplication(
             obo_client_id,
             client_credential=os.getenv("OBO_CLIENT_SECRET"),
-            authority=config.get("authority"))
+            authority=config.get("authority"),
+            # token_cache= ...,  # Default token cache is all-tokens-store-in-memory.
+                # That's fine if OBO app uses short-lived msal instance per session.
+                # Otherwise, the OBO app need to implement a one-cache-per-user setup.
+            )
         cca_result = cca.acquire_token_on_behalf_of(
-            pca_result['access_token'], obo_scopes)
+            pca_result['access_token'], downstream_scopes)
         self.assertNotEqual(None, cca_result.get("access_token"), str(cca_result))
 
-        # Cache would also work, with the one-cache-per-user caveat.
-        if len(cca.get_accounts()) == 1:
-            account = cca.get_accounts()[0]  # This test involves only 1 account
-            result = cca.acquire_token_silent(obo_scopes, account)
+        # 3. Now the OBO app can simply store downstream token(s) in same session.
+        #    Alternatively, if you want to persist the downstream AT, and possibly
+        #    the RT (if any) for prolonged access even after your own AT expires,
+        #    now it is the time to persist current cache state for current user.
+        #    Assuming you already did that (which is not shown in this test case),
+        #    the following part shows one of the ways to obtain an AT from cache.
+        username = cca_result.get("id_token_claims", {}).get("preferred_username")
+        self.assertEqual(config["username"], username)
+        if username:  # A precaution so that we won't use other user's token
+            account = cca.get_accounts(username=username)[0]
+            result = cca.acquire_token_silent(downstream_scopes, account)
             self.assertEqual(cca_result["access_token"], result["access_token"])
 


### PR DESCRIPTION
What
-----
This PR will solve #53.

How was it implemented
--------------------------
While the actual implementation is technically a one-liner `return ...`, there are some design decisions documented as inline comments inside both the implementation and the test case. Review/feedbacks are welcome.

The configuration of test case is reused from [a similar test case in MSAL .Net](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.3.1/tests/Microsoft.Identity.Test.Integration.net45/HeadlessTests/OboTests.cs).

How the new API looks like
-----------------------------
This is the [updated API reference document](https://msal-python.readthedocs.io/en/obo/#msal.ConfidentialClientApplication.acquire_token_on_behalf_of), please also proofread.

How to install this not-yet-released feature for testing
-----------------------------------------------
If you prefer to, you can install this branch for your smoke testing:

    pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@obo

What's Next
-------------
* We will provide an OBO sample at a later time, as a separated repo.
* We may provide a wiki page, similar to [the MSAL .Net one](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/on-behalf-of)
* Figure out how to add/modify [this docs page](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-web-api-call-api-app-configuration) to include a code snippet for MSAL Python