### PR TITLE
B2c implementation

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -18,7 +18,12 @@ WELL_KNOWN_AUTHORITY_HOSTS = set([
     'login.microsoftonline.us',
     'login.microsoftonline.de',
     ])
-
+WELL_KNOWN_B2C_HOSTS = [
+    "b2clogin.com",
+    "b2clogin.cn",
+    "b2clogin.us",
+    "b2clogin.de",
+    ]
 
 class Authority(object):
     """This class represents an (already-validated) authority.
@@ -43,7 +48,7 @@ class Authority(object):
         self.proxies = proxies
         self.timeout = timeout
         authority, self.instance, tenant = canonicalize(authority_url)
-        is_b2c = self.instance.endswith(".b2clogin.com")
+        is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS)
         if (tenant != "adfs" and (not is_b2c) and validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -40,19 +40,19 @@ class TestAuthority(unittest.TestCase):
 class TestAuthorityInternalHelperCanonicalize(unittest.TestCase):
 
     def test_canonicalize_tenant_followed_by_extra_paths(self):
-        self.assertEqual(
-            canonicalize("https://example.com/tenant/subpath?foo=bar#fragment"),
-            ("https://example.com/tenant", "example.com", "tenant"))
+        _, i, t = canonicalize("https://example.com/tenant/subpath?foo=bar#fragment")
+        self.assertEqual("example.com", i)
+        self.assertEqual("tenant", t)
 
     def test_canonicalize_tenant_followed_by_extra_query(self):
-        self.assertEqual(
-            canonicalize("https://example.com/tenant?foo=bar#fragment"),
-            ("https://example.com/tenant", "example.com", "tenant"))
+        _, i, t = canonicalize("https://example.com/tenant?foo=bar#fragment")
+        self.assertEqual("example.com", i)
+        self.assertEqual("tenant", t)
 
     def test_canonicalize_tenant_followed_by_extra_fragment(self):
-        self.assertEqual(
-            canonicalize("https://example.com/tenant#fragment"),
-            ("https://example.com/tenant", "example.com", "tenant"))
+        _, i, t = canonicalize("https://example.com/tenant#fragment")
+        self.assertEqual("example.com", i)
+        self.assertEqual("tenant", t)
 
     def test_canonicalize_rejects_non_https(self):
         with self.assertRaises(ValueError):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -18,7 +18,7 @@ def _get_app_and_auth_code(
         client_secret=None,
         authority="https://login.microsoftonline.com/common",
         port=44331,
-        scopes=["https://graph.windows.net/.default"],
+        scopes=["https://graph.microsoft.com/.default"],  # Microsoft Graph
         ):
     from msal.oauth2cli.authcode import obtain_auth_code
     app = msal.ClientApplication(client_id, client_secret, authority=authority)


### PR DESCRIPTION
There is an automated test case in this PR to cover username password flow (i.e. ROPC grant), and it passes.

Currently, this implementation is still considered in an early stage. We can use it as a prototype to [work on some sample as proof-of-concept](https://github.com/Azure-Samples/ms-identity-python-webapp/pull/4), in order to get the whole picture of end-to-end experience of the "new" API surface and calling patterns. The interesting part of this PR, is something NOT in this PR: You will see this PR did NOT touch the source file `application.py` which contains current public API definition. That means, we keep the high level API surface unchanged for B2C and non-B2C scenarios.

We can install this branch by:

    pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@b2c

We can organize a code walk-through when we officially start the PR code review at a later time.

This PR will eventually resolve #52 .