### PR TITLE
Enable Python 3.8 in test automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
+    - python: 3.8
+      dist: xenial
+      sudo: true
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
[Python 3.8.0](https://www.python.org/downloads/release/python-380/) has been released yesterday. Now we include it in our test automation matrix.