### PR TITLE
force_refresh not being passed to _acquire_token_silent_from_cache ....

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -413,7 +413,7 @@ class ClientApplication(object):
         #     verify=self.verify, proxies=self.proxies, timeout=self.timeout,
         #     ) if authority else self.authority
         result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
-            scopes, account, self.authority, **kwargs)
+            scopes, account, self.authority, force_refresh, **kwargs)
         if result:
             return result
         for alias in self._get_authority_aliases(self.authority.instance):

--- a/msal/application.py
+++ b/msal/application.py
@@ -413,7 +413,7 @@ class ClientApplication(object):
         #     verify=self.verify, proxies=self.proxies, timeout=self.timeout,
         #     ) if authority else self.authority
         result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
-            scopes, account, self.authority, force_refresh, **kwargs)
+            scopes, account, self.authority, force_refresh=force_refresh, **kwargs)
         if result:
             return result
         for alias in self._get_authority_aliases(self.authority.instance):


### PR DESCRIPTION
acquire_token_silent is receiving force_refresh but it's not passing to the next function: _acquire_token_silent_from_cache_and_possibly_refresh_it. This update just adds that argument when calling the latter.