### PR TITLE
Changing B2C implementation to verify policy format

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -48,8 +48,9 @@ class Authority(object):
         self.proxies = proxies
         self.timeout = timeout
         authority, self.instance, tenant = canonicalize(authority_url)
-        is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS)
-        if (tenant != "adfs" and (not is_b2c) and validate_authority
+        self.is_b2c = True if len(authority.path.split('/')) == 3 \
+                              and authority.path.split('/')[2].startswith("B2C") else False
+        if (tenant != "adfs" and (not self.is_b2c) and validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(
                 "https://{}{}/oauth2/v2.0/authorize".format(

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -18,6 +18,12 @@ WELL_KNOWN_AUTHORITY_HOSTS = set([
     'login.microsoftonline.us',
     'login.microsoftonline.de',
     ])
+WELL_KNOWN_B2C_HOSTS = [
+    "b2clogin.com",
+    "b2clogin.cn",
+    "b2clogin.us",
+    "b2clogin.de",
+    ]
 
 class Authority(object):
     """This class represents an (already-validated) authority.
@@ -42,9 +48,10 @@ class Authority(object):
         self.proxies = proxies
         self.timeout = timeout
         authority, self.instance, tenant = canonicalize(authority_url)
-        self.is_b2c = True if len(authority.path.split('/')) == 3 \
-                              and authority.path.split('/')[2].startswith("B2C") else False
-        if (tenant != "adfs" and (not self.is_b2c) and validate_authority
+        is_b2c = True if any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or \
+                         (len(authority.path.split('/')) == 3
+                          and authority.path.split('/')[2].lower().startswith("b2c_")) else False
+        if (tenant != "adfs" and (not is_b2c) and validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(
                 "https://{}{}/oauth2/v2.0/authorize".format(

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -49,8 +49,8 @@ class Authority(object):
         self.timeout = timeout
         authority, self.instance, tenant = canonicalize(authority_url)
         parts = authority.path.split('/')
-        is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or \
-                         (len(parts) == 3 and parts[2].lower().startswith("b2c_"))
+        is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or (
+            len(parts) == 3 and parts[2].lower().startswith("b2c_"))
         if (tenant != "adfs" and (not is_b2c) and validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -49,8 +49,8 @@ class Authority(object):
         self.timeout = timeout
         authority, self.instance, tenant = canonicalize(authority_url)
         parts = authority.path.split('/')
-        is_b2c = True if any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or \
-                         (len(parts) == 3 and parts[2].lower().startswith("b2c_")) else False
+        is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or \
+                         (len(parts) == 3 and parts[2].lower().startswith("b2c_"))
         if (tenant != "adfs" and (not is_b2c) and validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -18,12 +18,6 @@ WELL_KNOWN_AUTHORITY_HOSTS = set([
     'login.microsoftonline.us',
     'login.microsoftonline.de',
     ])
-WELL_KNOWN_B2C_HOSTS = [
-    "b2clogin.com",
-    "b2clogin.cn",
-    "b2clogin.us",
-    "b2clogin.de",
-    ]
 
 class Authority(object):
     """This class represents an (already-validated) authority.

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -48,9 +48,9 @@ class Authority(object):
         self.proxies = proxies
         self.timeout = timeout
         authority, self.instance, tenant = canonicalize(authority_url)
+        parts = authority.path.split('/')
         is_b2c = True if any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or \
-                         (len(authority.path.split('/')) == 3
-                          and authority.path.split('/')[2].lower().startswith("b2c_")) else False
+                         (len(parts) == 3 and parts[2].lower().startswith("b2c_")) else False
         if (tenant != "adfs" and (not is_b2c) and validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(


### PR DESCRIPTION
- Changing implementation to check for policy string format instead of b2clogin.com
- This supports custom domains with validateAuthority = True and sovereign clouds