### PR TITLE
Demo how to disable MSAL log

### DIFF
--- a/sample/confidential_client_certificate_sample.py
+++ b/sample/confidential_client_certificate_sample.py
@@ -37,7 +37,8 @@ import msal
 
 
 # Optional logging
-# logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)  # Enable DEBUG log for entire script
+# logging.getLogger("msal").setLevel(logging.INFO)  # Optionally disable MSAL DEBUG logs
 
 config = json.load(open(sys.argv[1]))
 

--- a/sample/confidential_client_secret_sample.py
+++ b/sample/confidential_client_secret_sample.py
@@ -36,7 +36,8 @@ import msal
 
 
 # Optional logging
-# logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)  # Enable DEBUG log for entire script
+# logging.getLogger("msal").setLevel(logging.INFO)  # Optionally disable MSAL DEBUG logs
 
 config = json.load(open(sys.argv[1]))
 

--- a/sample/device_flow_sample.py
+++ b/sample/device_flow_sample.py
@@ -26,7 +26,8 @@ import msal
 
 
 # Optional logging
-# logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)  # Enable DEBUG log for entire script
+# logging.getLogger("msal").setLevel(logging.INFO)  # Optionally disable MSAL DEBUG logs
 
 config = json.load(open(sys.argv[1]))
 

--- a/sample/username_password_sample.py
+++ b/sample/username_password_sample.py
@@ -28,7 +28,8 @@ import msal
 
 
 # Optional logging
-# logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)  # Enable DEBUG log for entire script
+# logging.getLogger("msal").setLevel(logging.INFO)  # Optionally disable MSAL DEBUG logs
 
 config = json.load(open(sys.argv[1]))
 


### PR DESCRIPTION
We were drafting this [logging wiki page](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki/Logging) and then realize that we could also add one more line per sample to demonstrate how to disable MSAL log while still enabling debug log for app dev's all other modules.