### PR TITLE
Add setup.cfg to build universal wheel by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_wheel]
+universal=1
+


### PR DESCRIPTION
Per conversation in #115 , this PR will guide all future builds to produce a universal wheel.