### PR TITLE
MSAL Python 1.0.0

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -18,7 +18,7 @@ from .token_cache import TokenCache
 
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "0.9.0"
+__version__ = "1.0.0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Release Notes:

There is no actual change between the previous 0.9.0 release and this release.
The major version number is bumped to have a 1.0.0 release. This indicates that the API surface in MSAL Python 1.0.0 is now stable and production ready. You may learn more about Versioning from [Semantic Versioning FAQ](https://semver.org/#how-do-i-know-when-to-release-100).