### PR TITLE
Adding support for exposing sub errors

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -423,7 +423,7 @@ class ClientApplication(object):
         result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
             scopes, account, self.authority, force_refresh=force_refresh, **kwargs)
         if result:
-            if "error" not in result:
+            if "access_token" in result:
                 return result
         for alias in self._get_authority_aliases(self.authority.instance):
             the_authority = Authority(

--- a/msal/application.py
+++ b/msal/application.py
@@ -521,6 +521,7 @@ class ClientApplication(object):
             # target=scopes,  # AAD RTs are scope-independent
             query=query)
         error_object = None
+        skip_sub_errors = ["bad_token", "token_expired", "client_mismatch", "device_authentication_failed"]
         logger.debug("Found %d RTs matching %s", len(matches), query)
         client = self._build_client(self.client_credential, authority)
         for entry in matches:
@@ -533,10 +534,10 @@ class ClientApplication(object):
             if "error" not in response:
                 return response
             else:
-                #the implementation for internal suberror codes like bad_token , token_expired WOULD COME HERE
-                error_object = response
-            logger.debug(
-                "Refresh failed. {error}: {error_description}".format(**response))
+                if response.get("suberror") not in skip_sub_errors:
+                    error_object = response
+                logger.debug(
+                    "Refresh failed. {error}: {error_description}".format(**response))
             if break_condition(response):
                 break
         return error_object

--- a/msal/application.py
+++ b/msal/application.py
@@ -447,6 +447,7 @@ class ClientApplication(object):
         if result:
             if result.get("access_token"):
                 return result
+            response = result
         for alias in self._get_authority_aliases(self.authority.instance):
             the_authority = Authority(
                 "https://" + alias + "/" + self.authority.tenant,
@@ -457,10 +458,11 @@ class ClientApplication(object):
             if result:
                 if result.get("access_token"):
                     return result
+                response = result
         if error_response:
-            if result and result.get("suberror"):
-                if result.get("suberror") not in set(["bad_token", "token_expired", "client_mismatch"]):
-                    response = Error(result['error'], result['error_description'], result['suberror'])
+            if response and response.get("suberror"):
+                if response.get("suberror") not in set(["bad_token", "token_expired", "client_mismatch"]):
+                    response = Error(response['error'], response['error_description'], response['suberror'])
         return response
 
     def _acquire_token_silent_from_cache_and_possibly_refresh_it(

--- a/msal/application.py
+++ b/msal/application.py
@@ -409,9 +409,16 @@ class ClientApplication(object):
         :param force_refresh:
             If True, it will skip Access Token look-up,
             and try to find a Refresh Token to obtain a new Access Token.
+        :param error_response:
+            A boolean flag for whether returning error response.
+            Default value is False, which will just return None instead of error.
+
         :return:
             - A dict containing "access_token" key, when cache lookup succeeds.
             - None when cache lookup does not yield anything.
+            - An Error object containing the error response,
+               this will be available only when an error actually happens,
+               and when the "error_response" parameter was True.
         """
         assert isinstance(scopes, list), "Invalid parameter type"
         self._validate_ssh_cert_input_data(kwargs.get("data", {}))

--- a/msal/application.py
+++ b/msal/application.py
@@ -430,7 +430,6 @@ class ClientApplication(object):
             if error_response:
                 if result.get("suberror") in set(["bad_token", "token_expired", "client_mismatch"]):
                     result = None
-                print(result)
                 return Error(result['error'], result['error_description'], result['suberror'])
         for alias in self._get_authority_aliases(self.authority.instance):
             the_authority = Authority(

--- a/msal/application.py
+++ b/msal/application.py
@@ -422,8 +422,9 @@ class ClientApplication(object):
         #     ) if authority else self.authority
         result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
             scopes, account, self.authority, force_refresh=force_refresh, **kwargs)
-        if "error" not in result:
-            return result
+        if result:
+            if "error" not in result:
+                return result
         for alias in self._get_authority_aliases(self.authority.instance):
             the_authority = Authority(
                 "https://" + alias + "/" + self.authority.tenant,
@@ -494,14 +495,16 @@ class ClientApplication(object):
                     # https://msazure.visualstudio.com/One/_git/ESTS-Docs/pullrequest/1138595
                     "client_mismatch" in response.get("error_additional_info", []),
                 **kwargs)
-            if "error" not in response:
-                return response
+            if response:
+                if "error" not in response:
+                    return response
         if app_metadata.get("family_id"):  # Meaning this app belongs to this family
             response = self._acquire_token_silent_by_finding_specific_refresh_token(
                 authority, scopes, dict(query, family_id=app_metadata["family_id"]),
                 **kwargs)
-            if "error" not in response:
-                return response
+            if response:
+                if "error" not in response:
+                    return response
         # Either this app is an orphan, so we will naturally use its own RT;
         # or all attempts above have failed, so we fall back to non-foci behavior.
         return self._acquire_token_silent_by_finding_specific_refresh_token(

--- a/msal/application.py
+++ b/msal/application.py
@@ -462,7 +462,9 @@ class ClientApplication(object):
         if error_response:
             if response and response.get("suberror"):
                 if response.get("suberror") not in set(["bad_token", "token_expired", "client_mismatch"]):
-                    response = Error(response['error'], response['error_description'], response['suberror'])
+                    response["classification"] = response.pop("suberror")
+                    return response
+        response = None
         return response
 
     def _acquire_token_silent_from_cache_and_possibly_refresh_it(

--- a/msal/application.py
+++ b/msal/application.py
@@ -462,7 +462,7 @@ class ClientApplication(object):
             scopes, account, self.authority, force_refresh=force_refresh,
             correlation_id=correlation_id,
             **kwargs)
-        if result:
+        if result and result.get("access_token"):
             return result
         for alias in self._get_authority_aliases(self.authority.instance):
             the_authority = Authority(
@@ -473,7 +473,7 @@ class ClientApplication(object):
                 scopes, account, the_authority, force_refresh=force_refresh,
                 correlation_id=correlation_id,
                 **kwargs)
-            if result:
+            if result and result.get("access_token"):
                 return result
 
     def acquire_token_silent_with_errors(
@@ -507,7 +507,7 @@ class ClientApplication(object):
         assert isinstance(scopes, list), "Invalid parameter type"
         self._validate_ssh_cert_input_data(kwargs.get("data", {}))
         correlation_id = _get_new_correlation_id()
-        response= None
+        response = None
         if authority:
             warnings.warn("We haven't decided how/if this method will accept authority parameter")
         # the_authority = Authority(
@@ -516,7 +516,7 @@ class ClientApplication(object):
         #     ) if authority else self.authority
         result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
             scopes, account, self.authority, force_refresh=force_refresh,
-            correlation_id=correlation_id, error_response=True,
+            correlation_id=correlation_id,
             **kwargs)
         if result:
             if result.get("access_token"):
@@ -548,7 +548,6 @@ class ClientApplication(object):
             account,  # type: Optional[Account]
             authority,  # This can be different than self.authority
             force_refresh=False,  # type: Optional[boolean]
-            error_response=False,  # type: Optional[boolean]
             **kwargs):
         if not force_refresh:
             query={
@@ -577,10 +576,10 @@ class ClientApplication(object):
                     }
         return self._acquire_token_silent_by_finding_rt_belongs_to_me_or_my_family(
                 authority, decorate_scope(scopes, self.client_id), account,
-                force_refresh=force_refresh, error_response=error_response, **kwargs)
+                force_refresh=force_refresh, **kwargs)
 
     def _acquire_token_silent_by_finding_rt_belongs_to_me_or_my_family(
-            self, authority, scopes, account, error_response, **kwargs):
+            self, authority, scopes, account, **kwargs):
         query = {
             "environment": authority.instance,
             "home_account_id": (account or {}).get("home_account_id"),
@@ -601,19 +600,19 @@ class ClientApplication(object):
                     # Based on an AAD-only behavior mentioned in internal doc here
                     # https://msazure.visualstudio.com/One/_git/ESTS-Docs/pullrequest/1138595
                     "client_mismatch" in response.get("error_additional_info", []),
-                error_response=error_response, **kwargs)
-            if result:
+                **kwargs)
+            if result and result.get("access_token"):
                 return result
         if app_metadata.get("family_id"):  # Meaning this app belongs to this family
             result = self._acquire_token_silent_by_finding_specific_refresh_token(
                 authority, scopes, dict(query, family_id=app_metadata["family_id"]),
-                error_response=error_response, **kwargs)
-            if result:
+                **kwargs)
+            if result and result.get("access_token"):
                 return result
         # Either this app is an orphan, so we will naturally use its own RT;
         # or all attempts above have failed, so we fall back to non-foci behavior.
         return self._acquire_token_silent_by_finding_specific_refresh_token(
-            authority, scopes, dict(query, client_id=self.client_id), error_response=error_response,
+            authority, scopes, dict(query, client_id=self.client_id),
             **kwargs)
 
     def _get_app_metadata(self, environment):
@@ -647,8 +646,7 @@ class ClientApplication(object):
                 **kwargs)
             if "error" not in response:
                 return response
-            if error_response:
-                result = response
+            result = response
             logger.debug(
                 "Refresh failed. {error}: {error_description}".format(**response))
             if break_condition(response):

--- a/msal/application.py
+++ b/msal/application.py
@@ -429,7 +429,7 @@ class ClientApplication(object):
         :return:
             - A dict containing "access_token" key, when cache lookup succeeds.
             - None when cache lookup does not yield anything.
-            - An Error object containing the error response,
+            - A dict containing the error response with classification of the error,
                this will be available only when an error actually happens,
                and when the "error_response" parameter was True.
         """

--- a/msal/exceptions.py
+++ b/msal/exceptions.py
@@ -37,10 +37,3 @@ class MsalServiceError(MsalError):
     msg = u"{error}: {error_description}"
 
 
-class Error(object):
-
-    def __init__(self, error_code=None, error_message=None, classification=None):
-        self.error_code = error_code
-        self.error_message = error_message
-        self.classification = classification
-

--- a/msal/exceptions.py
+++ b/msal/exceptions.py
@@ -36,4 +36,3 @@ class MsalError(Exception):
 class MsalServiceError(MsalError):
     msg = u"{error}: {error_description}"
 
-

--- a/msal/exceptions.py
+++ b/msal/exceptions.py
@@ -36,3 +36,11 @@ class MsalError(Exception):
 class MsalServiceError(MsalError):
     msg = u"{error}: {error_description}"
 
+
+class Error(object):
+
+    def __init__(self, error_code=None, error_message=None, classification=None):
+        self.error_code = error_code
+        self.error_message = error_message
+        self.classification = classification
+

--- a/sample/username_password_sample_with_classification.py
+++ b/sample/username_password_sample_with_classification.py
@@ -77,7 +77,9 @@ if accounts:
             elif option == "user_password_expired":
                 print("User password expired")
             else:
-                print("Invoke default error handling routine")
+                result = app.acquire_token_by_username_password(
+                    config["username"], config["password"], scopes=config["scope"])
+                print(json.dumps(result, indent=4))
 
 else:
     result = app.acquire_token_by_username_password(

--- a/sample/username_password_sample_with_classification.py
+++ b/sample/username_password_sample_with_classification.py
@@ -57,49 +57,40 @@ print("Accounts"+ str(accounts))
 if accounts:
     logging.info("Account(s) exists in cache, probably with token too. Let's try.")
     result = app.acquire_token_silent(config["scope"], account=accounts[0], error_response=True)
-    if result:
-        if isinstance(result, Error):
-            option = result.classification
-            if option == "basic_action":
-                print("""Condition can be resolved by user interaction 
-                during the interactive authentication flow.""")
-            elif option == "additional_action":
-                print("""Condition can be resolved by additional remedial interaction
-                with the system, outside of the interactive authentication flow.""")
-            elif option == "message_only":
-                print("""Condition cannot be resolved at this time.
-                Launching interactive authentication flow will show a message 
-                explaining the condition.""")
-                sys.exit("Abort without bothering to try acquire_token_by_xyz()")
-            elif option == "consent_required":
-                print("""Condition can be resolved by giving consent 
-                during the interactive authentication flow.""")
-            elif option == "user_password_expired":
-                print("User password expired")
-            else:
-                result = app.acquire_token_by_username_password(
-                    config["username"], config["password"], scopes=config["scope"])
-                print(json.dumps(result, indent=4))
 
-else:
+if not result:
+    logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
+    # See this page for constraints of Username Password Flow.
+    # https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki/Username-Password-Authentication
     result = app.acquire_token_by_username_password(
-            config["username"], config["password"], scopes=config["scope"])
-    print(json.dumps(result, indent=4))
+        config["username"], config["password"], scopes=config["scope"])
 
-if type(result) is dict:
-    if "access_token" in result:
-        print(result["access_token"])
-        print(result["token_type"])
-        print(result["expires_in"])  # You don't normally need to care about this.
-        # It will be good for at least 5 minutes.
-        graph_data = requests.get(  # Use token to call downstream service
-            config["endpoint"],
-            headers={'Authorization': 'Bearer ' + result['access_token']}, ).json()
-        print("Graph API call result: %s" % json.dumps(graph_data, indent=2))
+if "access_token" in result:
+    # Calling graph using the access token
+    graph_data = requests.get(  # Use token to call downstream service
+        config["endpoint"],
+        headers={'Authorization': 'Bearer ' + result['access_token']}, ).json()
+    print("Graph API call result: %s" % json.dumps(graph_data, indent=2))
+else:
+    option = result.get("classification")
+    if option == "basic_action":
+        print("""Condition can be resolved by user interaction 
+        during the interactive authentication flow.""")
+    elif option == "additional_action":
+        print("""Condition can be resolved by additional remedial interaction
+        with the system, outside of the interactive authentication flow.""")
+    elif option == "message_only":
+        print("""Condition cannot be resolved at this time.
+        Launching interactive authentication flow will show a message 
+        explaining the condition.""")
+        sys.exit("Abort without bothering to try acquire_token_by_xyz()")
+    elif option == "consent_required":
+        print("""Condition can be resolved by giving consent 
+        during the interactive authentication flow.""")
+    elif option == "user_password_expired":
+        print("User password expired")
     else:
-        print(result.get("error"))
-        print(result.get("error_description"))
-        print(result.get("correlation_id"))  # You may need this when reporting a bug
-        if 65001 in result.get("error_codes", []):  # Not mean to be coded programatically, but...
-            # AAD requires user consent for U/P flow
-            print("Visit this to consent:", app.get_authorization_request_url(config['scope']))
+        print("Default error handling behaviour")
+        result = app.acquire_token_by_username_password(
+            config["username"], config["password"], scopes=config["scope"])
+        print(json.dumps(result, indent=4))

--- a/sample/username_password_sample_with_classification.py
+++ b/sample/username_password_sample_with_classification.py
@@ -1,0 +1,103 @@
+
+"""
+The configuration file would look like this:
+
+{
+    "authority": "https://login.microsoftonline.com/organizations",
+    "client_id": "your_client_id",
+    "username": "your_username@your_tenant.com",
+    "scope": ["User.Read"],
+    "password": "This is a sample only. You better NOT persist your password."
+}
+
+You can then run this sample with a JSON configuration file:
+
+    python sample.py parameters.json
+"""
+
+import sys  # For simplicity, we'll read config file from 1st CLI param sys.argv[1]
+import json
+import logging
+
+import requests
+
+import msal
+import os, atexit
+from msal.exceptions import Error
+
+cache = msal.SerializableTokenCache()
+if os.path.exists("my_cache.bin"):
+    cache.deserialize(open("my_cache.bin", "r").read())
+atexit.register(lambda:
+    open("my_cache.bin", "w").write(cache.serialize())
+    # Hint: The following optional line persists only when state changed
+    if cache.has_state_changed else None
+    )
+
+
+# Optional logging
+# logging.basicConfig(level=logging.DEBUG)
+
+config = json.load(open(sys.argv[1]))
+
+# Create a preferably long-lived app instance which maintains a token cache.
+app = msal.PublicClientApplication(
+    config["client_id"], authority=config["authority"], validate_authority=False, token_cache=cache
+    # token_cache=...  # Default cache is in memory only.
+                       # You can learn how to use SerializableTokenCache from
+                       # https://msal-python.rtfd.io/en/latest/#msal.SerializableTokenCache
+    )
+
+# The pattern to acquire a token looks like this.
+result = None
+
+# Firstly, check the cache to see if this end user has signed in before
+accounts = app.get_accounts(username=config["username"])
+print("Accounts"+ str(accounts))
+if accounts:
+    logging.info("Account(s) exists in cache, probably with token too. Let's try.")
+    result = app.acquire_token_silent(config["scope"], account=accounts[0], error_response=True)
+    if result:
+        if isinstance(result, Error):
+            option = result.classification
+            if option == "basic_action":
+                print("""Condition can be resolved by user interaction 
+                during the interactive authentication flow.""")
+            elif option == "additional_action":
+                print("""Condition can be resolved by additional remedial interaction
+                with the system, outside of the interactive authentication flow.""")
+            elif option == "message_only":
+                print("""Condition cannot be resolved at this time.
+                Launching interactive authentication flow will show a message 
+                explaining the condition.""")
+                sys.exit("Abort without bothering to try acquire_token_by_xyz()")
+            elif option == "consent_required":
+                print("""Condition can be resolved by giving consent 
+                during the interactive authentication flow.""")
+            elif option == "user_password_expired":
+                print("User password expired")
+            else:
+                print("Invoke default error handling routine")
+
+else:
+    result = app.acquire_token_by_username_password(
+            config["username"], config["password"], scopes=config["scope"])
+    print(json.dumps(result, indent=4))
+
+if type(result) is dict:
+    if "access_token" in result:
+        print(result["access_token"])
+        print(result["token_type"])
+        print(result["expires_in"])  # You don't normally need to care about this.
+        # It will be good for at least 5 minutes.
+        graph_data = requests.get(  # Use token to call downstream service
+            config["endpoint"],
+            headers={'Authorization': 'Bearer ' + result['access_token']}, ).json()
+        print("Graph API call result: %s" % json.dumps(graph_data, indent=2))
+    else:
+        print(result.get("error"))
+        print(result.get("error_description"))
+        print(result.get("correlation_id"))  # You may need this when reporting a bug
+        if 65001 in result.get("error_codes", []):  # Not mean to be coded programatically, but...
+            # AAD requires user consent for U/P flow
+            print("Visit this to consent:", app.get_authorization_request_url(config['scope']))

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -226,5 +226,5 @@ class TestClientApplicationForSuberrors(unittest.TestCase):
                 "error": "invalid_grant",
                 "error_description": "Was issued to another client",
                 "suberror": "basic_action"}))
-        response = app.acquire_token_silent(["s3"],self.account,authority=self.authority, post=tester)
-        self.assertEqual("basic_action", response.get("suberror"), "Exposes the suberror object")
+        response = app.acquire_token_silent(["s3"], self.account, authority=self.authority, post=tester, error_response=True)
+        self.assertEqual("basic_action", response.classification, "Exposes the suberror object")

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -227,4 +227,4 @@ class TestClientApplicationForSuberrors(unittest.TestCase):
                 "error_description": "Was issued to another client",
                 "suberror": "basic_action"}))
         response = app.acquire_token_silent(["s3"], self.account, authority=self.authority, post=tester, error_response=True)
-        self.assertEqual("basic_action", response.classification, "Exposes the suberror object")
+        self.assertEqual("basic_action", response.get("classification"), "Exposes the suberror object")


### PR DESCRIPTION
This is a draft.

---

Experimenting different flavors of API surface.

1. If the app developer "subscribes" the CA error by a container in parameter, [this is a sample](https://github.com/AzureAD/microsoft-authentication-library-for-python/compare/return-error-in-param?expand=1#diff-350433198f3b1800ace53a8ba389538c) to demonstrate what the differences are, comparing to the pre-CA sample.

