### PR TITLE
Lab API is switching to a new scope

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -306,7 +306,7 @@ class LabBasedTestCase(E2eTestCase):
     @classmethod
     def setUpClass(cls):
         # https://docs.msidlab.com/accounts/apiaccess.html#code-snippet
-        cls.session = get_session(get_lab_app(), ["https://user.msidlab.com/.default"])
+        cls.session = get_session(get_lab_app(), ["https://msidlab.com/.default"])
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Quoted from LAB team notice:

> Beginning ~5th December 2019 at 9:00 am~ 9th December 2019 at 11:00 am PST, the scope of the Lab Confidential Client will change from "https://user.msidlab.com/.default" to "https://msidlab.com/.default"

* This PR is currently failing because the actual change has not happened yet.
* You will notice our test automation on OTHER branches start failing after ~Dec 5 2019 9AM PST~ the time mentioned above, and then this branch/PR will start to pass the test. That is the time you are going to merge this PR.