### PR TITLE
Adding app_name and app_version headers

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -155,9 +155,9 @@ class ClientApplication(object):
             "x-client-cpu": "x64" if sys.maxsize > 2 ** 32 else "x86",
         }
         if app_name:
-            default_headers['app-name'] =  app_name
+            default_headers['x-app-name'] =  app_name
         if app_version:
-            default_headers['app-version'] = app_version
+            default_headers['x-app-ver'] = app_version
         default_body = {"client_info": 1}
         if isinstance(client_credential, dict):
             assert ("private_key" in client_credential

--- a/msal/application.py
+++ b/msal/application.py
@@ -131,6 +131,14 @@ class ClientApplication(object):
             It will be passed to the
             `timeout parameter in the underlying requests library
             <http://docs.python-requests.org/en/v2.9.1/user/advanced/#timeouts>`_
+        :param app_name: (optional)
+            You can provide your application name for telemetry purposes which will be
+            passed as an additional header value "x-app-name"
+            By default, the additional header value will not be passed
+        :param app_version: (optional)
+            You can provide your application version for telemetry purposes which will be
+            passed as an additional header value "x-app-ver"
+            By default, the additional header value will not be passed
         """
         self.client_id = client_id
         self.client_credential = client_credential
@@ -155,7 +163,7 @@ class ClientApplication(object):
             "x-client-cpu": "x64" if sys.maxsize > 2 ** 32 else "x86",
         }
         if app_name:
-            default_headers['x-app-name'] =  app_name
+            default_headers['x-app-name'] = app_name
         if app_version:
             default_headers['x-app-ver'] = app_version
         default_body = {"client_info": 1}

--- a/msal/application.py
+++ b/msal/application.py
@@ -146,12 +146,14 @@ class ClientApplication(object):
         self.verify = verify
         self.proxies = proxies
         self.timeout = timeout
+        self.app_name = app_name
+        self.app_version = app_version
         self.authority = Authority(
                 authority or "https://login.microsoftonline.com/common/",
                 validate_authority, verify=verify, proxies=proxies, timeout=timeout)
             # Here the self.authority is not the same type as authority in input
         self.token_cache = token_cache or TokenCache()
-        self.client = self._build_client(client_credential, self.authority, app_name, app_version)
+        self.client = self._build_client(client_credential, self.authority)
         self.authority_groups = None
 
     def _build_client(self, client_credential, authority, app_name=None, app_version=None):
@@ -162,10 +164,10 @@ class ClientApplication(object):
             "x-client-os": sys.platform,
             "x-client-cpu": "x64" if sys.maxsize > 2 ** 32 else "x86",
         }
-        if app_name:
-            default_headers['x-app-name'] = app_name
-        if app_version:
-            default_headers['x-app-ver'] = app_version
+        if self.app_name:
+            default_headers['x-app-name'] = self.app_name
+        if self.app_version:
+            default_headers['x-app-ver'] = self.app_version
         default_body = {"client_info": 1}
         if isinstance(client_credential, dict):
             assert ("private_key" in client_credential

--- a/msal/application.py
+++ b/msal/application.py
@@ -146,7 +146,7 @@ class ClientApplication(object):
         self.client = self._build_client(client_credential, self.authority, app_name, app_version)
         self.authority_groups = None
 
-    def _build_client(self, client_credential, authority, app_name, app_version):
+    def _build_client(self, client_credential, authority, app_name=None, app_version=None):
         client_assertion = None
         client_assertion_type = None
         default_headers = {

--- a/msal/application.py
+++ b/msal/application.py
@@ -156,7 +156,7 @@ class ClientApplication(object):
         self.client = self._build_client(client_credential, self.authority)
         self.authority_groups = None
 
-    def _build_client(self, client_credential, authority, app_name=None, app_version=None):
+    def _build_client(self, client_credential, authority):
         client_assertion = None
         client_assertion_type = None
         default_headers = {

--- a/msal/application.py
+++ b/msal/application.py
@@ -132,13 +132,11 @@ class ClientApplication(object):
             `timeout parameter in the underlying requests library
             <http://docs.python-requests.org/en/v2.9.1/user/advanced/#timeouts>`_
         :param app_name: (optional)
-            You can provide your application name for telemetry purposes which will be
-            passed as an additional header value "x-app-name"
-            By default, the additional header value will not be passed
+            You can provide your application name for Microsoft telemetry purposes.
+            Default value is None, means it will not be passed to Microsoft.
         :param app_version: (optional)
-            You can provide your application version for telemetry purposes which will be
-            passed as an additional header value "x-app-ver"
-            By default, the additional header value will not be passed
+            You can provide your application version for Microsoft telemetry purposes.
+            Default value is None, means it will not be passed to Microsoft.
         """
         self.client_id = client_id
         self.client_credential = client_credential

--- a/msal/application.py
+++ b/msal/application.py
@@ -73,7 +73,7 @@ class ClientApplication(object):
             client_credential=None, authority=None, validate_authority=True,
             token_cache=None,
             verify=True, proxies=None, timeout=None,
-            client_claims=None):
+            client_claims=None, app_name=None, app_version=None):
         """Create an instance of application.
 
         :param client_id: Your app has a client_id after you register it on AAD.
@@ -143,12 +143,21 @@ class ClientApplication(object):
                 validate_authority, verify=verify, proxies=proxies, timeout=timeout)
             # Here the self.authority is not the same type as authority in input
         self.token_cache = token_cache or TokenCache()
-        self.client = self._build_client(client_credential, self.authority)
+        self.client = self._build_client(client_credential, self.authority, app_name, app_version)
         self.authority_groups = None
 
-    def _build_client(self, client_credential, authority):
+    def _build_client(self, client_credential, authority, app_name, app_version):
         client_assertion = None
         client_assertion_type = None
+        default_headers = {
+            "x-client-sku": "MSAL.Python", "x-client-ver": __version__,
+            "x-client-os": sys.platform,
+            "x-client-cpu": "x64" if sys.maxsize > 2 ** 32 else "x86",
+        }
+        if app_name:
+            default_headers['app-name'] =  app_name
+        if app_version:
+            default_headers['app-version'] = app_version
         default_body = {"client_info": 1}
         if isinstance(client_credential, dict):
             assert ("private_key" in client_credential
@@ -174,11 +183,7 @@ class ClientApplication(object):
         return Client(
             server_configuration,
             self.client_id,
-            default_headers={
-                "x-client-sku": "MSAL.Python", "x-client-ver": __version__,
-                "x-client-os": sys.platform,
-                "x-client-cpu": "x64" if sys.maxsize > 2 ** 32 else "x86",
-                },
+            default_headers=default_headers,
             default_body=default_body,
             client_assertion=client_assertion,
             client_assertion_type=client_assertion_type,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -318,10 +318,8 @@ class LabBasedTestCase(E2eTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.session = get_session(get_lab_app(), [
-            "https://request.msidlab.com/.default",  # Existing user & password API
-            # "https://user.msidlab.com/.default",  # New user API
-            ])
+        # https://docs.msidlab.com/accounts/apiaccess.html#code-snippet
+        cls.session = get_session(get_lab_app(), ["https://msidlab.com/.default"])
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
~Resolves~ Addresses #130 <sub>Edited by Ray: Per the team-wide recent workflow, we have to avoid those magic keywords such as "resolves", in order to NOT close that issue until we actually release a new version containing this change.</sub>


For reference: The pattern MSAL Java uses is : 

```java
PublicClientApplication app = PublicClientApplication
                .builder("client-id")
                .correlationId("correlation-id")
                .applicationName("app-name")
                .applicationVersion("app-version")
                .build();
```

The API this PR will implemented will be:

```python
pca = PublicClientApplication(
    ...,
    app_name="my app",
    app_version="1.2.3",
    )
```