### PR TITLE
error_description is optional

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -578,8 +578,10 @@ class ClientApplication(object):
                 **kwargs)
             if "error" not in response:
                 return response
-            logger.debug(
-                "Refresh failed. {error}: {error_description}".format(**response))
+            logger.debug("Refresh failed. {error}: {error_description}".format(
+                error=response.get("error"),
+                error_description=response.get("error_description"),
+                ))
             if break_condition(response):
                 break
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -74,7 +74,7 @@ class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
         logger.debug("%s.cache = %s", self.id(), self.cache.serialize())
         def tester(url, data=None, **kwargs):
             self.assertEqual(self.frt, data.get("refresh_token"), "Should attempt the FRT")
-            return Mock(status_code=200, json=Mock(return_value={
+            return Mock(status_code=400, json=Mock(return_value={
                 "error": "invalid_grant",
                 "error_description": "Was issued to another client"}))
         app._acquire_token_silent_by_finding_rt_belongs_to_me_or_my_family(


### PR DESCRIPTION
Although empirically we saw `error_description` shows up in AAD response, it is an optional field, [per spec](https://tools.ietf.org/html/rfc6749#section-5.2).

In this PR, we adjust our implementation, to make it more robust.