### PR TITLE
New method acquire_token_silent_with_error()

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -431,11 +431,14 @@ class ClientApplication(object):
             **kwargs):
         """Acquire an access token for given account, without user interaction.
 
-        It behaves same as :func:`~acquire_token_silent_with_error`,
-        except that this method will combine the cache empty and refresh error
+        It is done either by finding a valid access token from cache,
+        or by finding a valid refresh token from cache and then automatically
+        use it to redeem a new access token.
+
+        This method will combine the cache empty and refresh error
         into one return value, `None`.
-        If your app does not need to care the exact token refresh error during
-        token cache look-up, then this method is easier to use.
+        If your app does not care about the exact token refresh error during
+        token cache look-up, then this method is easier and recommended.
 
         Internally, this method calls :func:`~acquire_token_silent_with_error`.
 
@@ -462,8 +465,10 @@ class ClientApplication(object):
         or by finding a valid refresh token from cache and then automatically
         use it to redeem a new access token.
 
-        Unlike :func:`~acquire_token_silent`,
-        error happened during token refresh would also be returned.
+        This method will differentiate cache empty from token refresh error.
+        If your app cares the exact token refresh error during
+        token cache look-up, then this method is suitable.
+        Otherwise, the other method :func:`~acquire_token_silent` is recommended.
 
         :param list[str] scopes: (Required)
             Scopes requested to access a protected API (a resource).

--- a/msal/application.py
+++ b/msal/application.py
@@ -509,6 +509,14 @@ class ClientApplication(object):
                 if "error" not in result:
                     return result
                 final_result = result
+        if final_result and final_result.get("suberror"):
+            final_result["classification"] = {  # Suppress these suberrors, per #57
+                "bad_token": "",
+                "token_expired": "",
+                "protection_policy_required": "",
+                "client_mismatch": "",
+                "device_authentication_failed": "",
+                }.get(final_result["suberror"], final_result["suberror"])
         return final_result
 
     def _acquire_token_silent_from_cache_and_possibly_refresh_it(

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -46,6 +46,49 @@ class TestHelperExtractCerts(unittest.TestCase):  # It is used by SNI scenario
         self.assertEqual(["my_cert1", "my_cert2"], extract_certs(pem))
 
 
+class TestClientApplicationAcquireTokenSilentErrorBehaviors(unittest.TestCase):
+
+    def setUp(self):
+        self.authority_url = "https://login.microsoftonline.com/common"
+        self.authority = msal.authority.Authority(self.authority_url)
+        self.scopes = ["s1", "s2"]
+        self.uid = "my_uid"
+        self.utid = "my_utid"
+        self.account = {"home_account_id": "{}.{}".format(self.uid, self.utid)}
+        self.rt = "this is a rt"
+        self.cache = msal.SerializableTokenCache()
+        self.client_id = "my_app"
+        self.cache.add({  # Pre-populate the cache
+            "client_id": self.client_id,
+            "scope": self.scopes,
+            "token_endpoint": "{}/oauth2/v2.0/token".format(self.authority_url),
+            "response": TokenCacheTestCase.build_response(
+                access_token="an expired AT to trigger refresh", expires_in=-99,
+                uid=self.uid, utid=self.utid, refresh_token=self.rt),
+            })  # The add(...) helper populates correct home_account_id for future searching
+        self.app = ClientApplication(
+            self.client_id, authority=self.authority_url, token_cache=self.cache)
+
+    def test_cache_empty_will_be_returned_as_None(self):
+        self.assertEqual(
+            None, self.app.acquire_token_silent(['cache_miss'], self.account))
+        self.assertEqual(
+            None, self.app.acquire_token_silent_with_error(['cache_miss'], self.account))
+
+    def test_acquire_token_silent_with_error_will_return_error(self):
+        error_response = {"error": "invalid_grant", "error_description": "xyz"}
+        def tester(url, **kwargs):
+            return Mock(status_code=400, json=Mock(return_value=error_response))
+        self.assertEqual(error_response, self.app.acquire_token_silent_with_error(
+            self.scopes, self.account, post=tester))
+
+    def test_acquire_token_silent_will_suppress_error(self):
+        error_response = {"error": "invalid_grant", "error_description": "xyz"}
+        def tester(url, **kwargs):
+            return Mock(status_code=400, json=Mock(return_value=error_response))
+        self.assertEqual(None, self.app.acquire_token_silent(
+            self.scopes, self.account, post=tester))
+
 class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
In an effort to address #57 , we need to expose some of the underlying token refreshing errors to app developer. After weighing different options (such as extending the existing `acquire_token_silent()` method with different style of opt-in flag: boolean, container, callback, ..., you name it), we chose to keep the original `acquire_token_silent()`'s behavior unchanged, and introduce a new `acquire_token_silent_with_error()` method.

The online documentation for both the old `acquire_token_silent()` and new `acquire_token_silent_with_error()` has also been updated and staged [here](https://msal-python.readthedocs.io/en/acquire_token_silent_with_error/#msal.ClientApplication.acquire_token_silent). Please also proofread.

Besides, quoted below is the upcoming Wiki page on how to use the new API to handle CA error. Please also proofread.

PS: Since @abhidnya13 is OOF, @navyasric please help take a look.
//CC @henrik-me 

---

To capture possible Conditional Access (CA) error, you can modify your app in this way.

Before:

```python
result = app.acquire_token_silent(your_scopes, account=your_account)
if not result:
    logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
    result = app.acquire_token_by_xyz_method(...)

if "access_token" in result:
    use_the_token(result["access_token"])
else:
    print(result.get("error"))
```

After:

```python
# Modification begins
result = app.acquire_token_silent_with_error(your_scopes, account=your_account)
successful = result and "error" not in result
if not successful:
    if result:  # CA error occurred. You can handle them specifically.
        print("There was a refresh token in cache, but it was rejected.")
        if result.get("classification") == "basic_action":
            print("""Condition can be resolved by user interaction
                during the interactive authentication flow.""")
        elif result.get("classification") == "additional_action":
            print("""Condition can be resolved by additional remedial interaction
                with the system, outside of the interactive authentication flow.""")
        elif result.get("classification") == "message_only":
            print("""Condition cannot be resolved at this time.
                Launching interactive authentication flow will NOT help,
                it would only show a message explaining the condition.""")
            sys.exit("Abort without bothering to try acquire_token_by_xyz()")
        else:
            print("Invoke default error handling routine")
# Modification ends

# The rest remains the same
    logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
    result = app.acquire_token_by_xyz_method(...)

if "access_token" in result:
    use_the_token(result["access_token"])
else:
    print(result.get("error"))
```