### PR TITLE
refactor authority for reusability/openid_config injection

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -73,10 +73,10 @@ class Authority(object):
         # "federation_metadata_url", "federation_active_auth_url", etc.
         if self.instance not in self.__class__._domains_without_user_realm_discovery:
             if response is None:
-                response = requests.get(**get_userrealm_discovery_request_info(instance=self.instance,
+                response = requests.get(verify=self.verify, proxies=self.proxies, timeout=self.timeout,
+                                        **get_userrealm_discovery_request_info(instance=self.instance,
                                                                                username=username,
-                                                                               correlation_id=correlation_id),
-                                        verify=self.verify, proxies=self.proxies, timeout=self.timeout)
+                                                                               correlation_id=correlation_id))
 
             discovery_payload = verify_user_realm_discovery_response(response)
 

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -114,7 +114,7 @@ def get_userrealm_discovery_request_info(instance, username, correlation_id):
 
 def get_instance_discovery_request_info(url):
     return {
-        "url": 'https://{}/common/discovery/instance'.format(
+        "url": 'https://{}/common/discovery/instance'.format(  # Note: This URL seemingly returns V1 endpoint only
             WORLD_WIDE  # Historically using WORLD_WIDE. Could use self.instance too
             # See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.0.0/src/Microsoft.Identity.Client/Instance/AadInstanceDiscovery.cs#L101-L103
             # and https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.0.0/src/Microsoft.Identity.Client/Instance/AadAuthority.cs#L19-L33
@@ -165,9 +165,8 @@ def canonicalize(authority_url):
     return authority, authority.hostname, parts[1]
 
 def instance_discovery(url, **kwargs):
-    return requests.get(  # Note: This URL seemingly returns V1 endpoint only
-        **get_instance_discovery_request_info(url=url),
-        **kwargs).json()
+    kwargs.update(get_instance_discovery_request_info(url))
+    return requests.get(**kwargs).json()
 
 def tenant_discovery(tenant_discovery_endpoint, **kwargs):
     # Returns Openid Configuration


### PR DESCRIPTION
General refactoring so that we can move towards shared logic between sync/async transports. 

Most notably it allows for clients to pass in an already formed `openid_config` while improving general reusability + readability.