### PR TITLE
Add source root dir to python path in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
conf.py imports the version from the local module, so it needs to have the
directory in the python path, otherwise it fails with:

$ sphinx-apidoc -f -e -o docs/api msal
Creating file docs/api/msal.application.rst.
Creating file docs/api/msal.authority.rst.
Creating file docs/api/msal.exceptions.rst.
Creating file docs/api/msal.mex.rst.
Creating file docs/api/msal.token_cache.rst.
Creating file docs/api/msal.wstrust_request.rst.
Creating file docs/api/msal.wstrust_response.rst.
Creating file docs/api/msal.rst.
Creating file docs/api/msal.oauth2cli.assertion.rst.
Creating file docs/api/msal.oauth2cli.authcode.rst.
Creating file docs/api/msal.oauth2cli.oauth2.rst.
Creating file docs/api/msal.oauth2cli.oidc.rst.
Creating file docs/api/msal.oauth2cli.rst.
Creating file docs/api/modules.rst.
$ make -C docs man
make: Entering directory '/home/bluca/git/microsoft-authentication-library-for-python/docs'
Running Sphinx v1.8.4

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/usr/lib/python3/dist-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/bluca/git/microsoft-authentication-library-for-python/docs/conf.py", line 27, in <module>
    from msal import __version__ as version
ModuleNotFoundError: No module named 'msal'

make: *** [Makefile:19: man] Error 2