### PR TITLE
move reserved scopes to a module level constant

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -22,10 +22,11 @@ from .token_cache import TokenCache
 __version__ = "1.1.0"
 
 logger = logging.getLogger(__name__)
+RESERVED_SCOPES = frozenset(['openid', 'profile', 'offline_access'])
 
 def decorate_scope(
         scopes, client_id,
-        reserved_scope=frozenset(['openid', 'profile', 'offline_access'])):
+        reserved_scope=RESERVED_SCOPES):
     if not isinstance(scopes, (list, set, tuple)):
         raise ValueError("The input scopes should be a list, tuple, or set")
     scope_set = set(scopes)  # Input scopes is typically a list. Copy it to a set.


### PR DESCRIPTION
We are wrapping this library and are allowing users to pass in scopes. We need to make sure they don't pass in any scopes that are reserved so that they don't receive an error. However, the `reserved_scope` is closed by the function so we need to move it outside for visibility.

I would also like some clarity on why this check is being performed anyway. It seems unnecessary since later we union the two sets or just use the reserved set itself. I believe this function violates the [principle of least astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) and this check of reserved scopes should be removed completely.