### PR TITLE
allow passing more parameters when generating auth uri

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -247,6 +247,7 @@ class ClientApplication(object):
             You will have to specify a value explicitly.
             Its valid values are defined in Open ID Connect specs
             https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+        :param kwargs: Other parameters, typically defined in OpenID Connect.
         :return: The authorization url as a string.
         """
         """ # TBD: this would only be meaningful in a new acquire_token_interactive()
@@ -276,6 +277,7 @@ class ClientApplication(object):
             redirect_uri=redirect_uri, state=state, login_hint=login_hint,
             prompt=prompt,
             scope=decorate_scope(scopes, self.client_id),
+            **kwargs
             )
 
     def acquire_token_by_authorization_code(


### PR DESCRIPTION
We are interested in adding some more parameters to the `get_authorization_request_url`. Currently, it appears we can only send the parameters explicitly stated in the `get_authorization_request_url` method, while there are more [possible parameters](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) than what is currently accepted.

Since the `client.build_auth_request_uri` already supports `kwargs`, we can pass kwargs to that function as well.