### PR TITLE
Allow domain hint

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -255,6 +255,7 @@ class ClientApplication(object):
         :param domain_hint:
             Provides a hint about the tenant or domain that the user should use to sign in. The value
             of the domain hint is a registered domain for the tenant.
+            https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code
         :return: The authorization url as a string.
         """
         """ # TBD: this would only be meaningful in a new acquire_token_interactive()

--- a/msal/application.py
+++ b/msal/application.py
@@ -230,6 +230,7 @@ class ClientApplication(object):
             response_type="code",  # Can be "token" if you use Implicit Grant
             prompt=None,
             nonce=None,
+            domain_hint=None,  # type: Optional[str]
             **kwargs):
         """Constructs a URL for you to start a Authorization Code Grant.
 
@@ -251,6 +252,9 @@ class ClientApplication(object):
         :param nonce:
             A cryptographically random value used to mitigate replay attacks. See also
             `OIDC specs <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_.
+        :param domain_hint:
+            Provides a hint about the tenant or domain that the user should use to sign in. The value
+            of the domain hint is a registered domain for the tenant.
         :return: The authorization url as a string.
         """
         """ # TBD: this would only be meaningful in a new acquire_token_interactive()
@@ -280,7 +284,7 @@ class ClientApplication(object):
             redirect_uri=redirect_uri, state=state, login_hint=login_hint,
             prompt=prompt,
             scope=decorate_scope(scopes, self.client_id),
-            nonce=nonce,
+            nonce=nonce, domain_hint=domain_hint,
             )
 
     def acquire_token_by_authorization_code(

--- a/msal/application.py
+++ b/msal/application.py
@@ -253,9 +253,11 @@ class ClientApplication(object):
             A cryptographically random value used to mitigate replay attacks. See also
             `OIDC specs <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_.
         :param domain_hint:
-            Provides a hint about the tenant or domain that the user should use to sign in. The value
-            of the domain hint is a registered domain for the tenant.
+            Can be one of "consumers" or "organizations" or your tenant domain "contoso.com".
+            If included, it will skip the email-based discovery process that user goes
+            through on the sign-in page, leading to a slightly more streamlined user experience.
             https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code
+            https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-oapx/86fb452d-e34a-494e-ac61-e526e263b6d8
         :return: The authorization url as a string.
         """
         """ # TBD: this would only be meaningful in a new acquire_token_interactive()
@@ -285,7 +287,8 @@ class ClientApplication(object):
             redirect_uri=redirect_uri, state=state, login_hint=login_hint,
             prompt=prompt,
             scope=decorate_scope(scopes, self.client_id),
-            nonce=nonce, domain_hint=domain_hint,
+            nonce=nonce,
+            domain_hint=domain_hint,
             )
 
     def acquire_token_by_authorization_code(


### PR DESCRIPTION
Allows user to pass in domain hint when generating authorization URL

---
UPDATED (by Ray):
This PR will fix #158. (This line will trigger an automatic close of that issue. This is probably fine, because we will cut a new release shortly after this merge.)