### PR TITLE
Improve error message on incorrect authority uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Before using MSAL Python (or any MSAL SDKs, for that matter), you will have to
 [register your application with the Microsoft identity platform](https://docs.microsoft.com/azure/active-directory/develop/quickstart-v2-register-an-app).
 
 Acquiring tokens with MSAL Python follows this 3-step pattern.
+(Note: That is the high level conceptual pattern.
+There will be some variations for different flows. They are demonstrated in
+[runnable samples hosted right in this repo](https://github.com/AzureAD/microsoft-authentication-library-for-python/tree/dev/sample).
+)
+
 
 1. MSAL proposes a clean separation between
    [public client applications, and confidential client applications](https://tools.ietf.org/html/rfc6749#section-2.1).
@@ -43,7 +48,9 @@ Acquiring tokens with MSAL Python follows this 3-step pattern.
 
    ```python
    from msal import PublicClientApplication
-   app = PublicClientApplication("your_client_id", authority="...")
+   app = PublicClientApplication(
+       "your_client_id",
+       "authority": "https://login.microsoftonline.com/Enter_the_Tenant_Name_Here")
    ```
 
    Later, each time you would want an access token, you start by:
@@ -67,7 +74,7 @@ Acquiring tokens with MSAL Python follows this 3-step pattern.
        # Assuming the end user chose this one
        chosen = accounts[0]
        # Now let's try to find a token in cache for this account
-       result = app.acquire_token_silent(config["scope"], account=chosen)
+       result = app.acquire_token_silent(["your_scope"], account=chosen)
    ```
 
 3. Either there is no suitable token in the cache, or you chose to skip the previous step,
@@ -85,9 +92,6 @@ Acquiring tokens with MSAL Python follows this 3-step pattern.
        print(result.get("error_description"))
        print(result.get("correlation_id"))  # You may need this when reporting a bug
    ```
-
-That is the high level pattern. There will be some variations for different flows. They are demonstrated in
-[samples hosted right in this repo](https://github.com/AzureAD/microsoft-authentication-library-for-python/tree/dev/sample).
 
 Refer the [Wiki](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki) pages for more details on the MSAL Python functionality and usage.
 

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -79,9 +79,16 @@ class Authority(object):
                     authority.path,  # In B2C scenario, it is "/tenant/policy"
                     "" if tenant == "adfs" else "/v2.0" # the AAD v2 endpoint
                     ))
-        openid_config = tenant_discovery(
-            tenant_discovery_endpoint,
-            self.http_client)
+        try:
+            openid_config = tenant_discovery(
+                tenant_discovery_endpoint,
+                self.http_client)
+        except json.decoder.JSONDecodeError:
+            raise ValueError(
+                "Unable to get authority configuration for {}. "
+                "Authority would typically be in a format of "
+                "https://login.microsoftonline.com/your_tenant_name".format(
+                authority_url))
         logger.debug("openid_config = %s", openid_config)
         self.authorization_endpoint = openid_config['authorization_endpoint']
         self.token_endpoint = openid_config['token_endpoint']

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -83,7 +83,7 @@ class Authority(object):
             openid_config = tenant_discovery(
                 tenant_discovery_endpoint,
                 self.http_client)
-        except json.decoder.JSONDecodeError:
+        except ValueError:  # json.decoder.JSONDecodeError in Py3 subclasses this
             raise ValueError(
                 "Unable to get authority configuration for {}. "
                 "Authority would typically be in a format of "


### PR DESCRIPTION
Today a customer was asking for our support on an error he encountered.

> I have registered my App on Azure Portal but hitting:
> `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`
>
> when using:
>
> ```python
> auth = "https://login.microsoftonline.com/common/oauth2/nativeclient"
> app = PublicClientApplication(client_id, authority=auth)
> ```

And he further explained:

> I first went to this [MSAL repo's homepage](https://github.com/AzureAD/microsoft-authentication-library-for-python)
> there seems a bug in README (`config` was not defined but `config["scope"]` was called), so I went to [samples hosted inside same MSAL repo](https://github.com/AzureAD/microsoft-authentication-library-for-python/tree/dev/sample)

Our takeaways:

* Customers expect code snippet in README to be runnable, or at least, with syntactically-correct placeholders which would NOT throw any exception.
* We used to use (overly?) flexible placeholder like "..." in this project's README. Perhaps we need to switch to a narrow example such as "https://login.microsoftonline.com/common" which is suitable to perhaps majority of customers (with the price that it is technically incorrect for B2C or ADFS customers).
* Catch lower level exceptions, and convert them into a meaningful ValueError("Your input  did not work because ...")

This PR addresses such 3 findings.