### PR TITLE
import_refresh_token() for RT migration

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -700,6 +700,28 @@ class ClientApplication(object):
                     "you must include a string parameter named 'key_id' "
                     "which identifies the key in the 'req_cnf' argument.")
 
+    def import_refresh_token(self, refresh_token, scopes):
+        """Import an RT from elsewhere into MSAL's token cache.
+
+        :param str refresh_token: The old refresh token, as a string.
+
+        :param list scopes:
+            The scopes associate with this old RT.
+            Each scope needs to be in the Microsoft identity platform (v2) format.
+            https://docs.microsoft.com/en-us/azure/active-directory/develop/migrate-python-adal-msal#scopes-not-resources
+
+        :return:
+            * A dict contains "error" and some other keys, when error happened.
+            * A dict contains no "error" key.
+        """
+        result = self.client.obtain_token_by_refresh_token(
+            refresh_token,
+            decorate_scope(scopes, self.client_id),
+            rt_getter=lambda rt: rt,
+            on_updating_rt=False,
+            )
+        return {} if "error" not in result else result  # Returns NO token
+
 
 class PublicClientApplication(ClientApplication):  # browser app or mobile app
 

--- a/sample/migrate_rt.py
+++ b/sample/migrate_rt.py
@@ -1,0 +1,75 @@
+"""
+The configuration file would look like this:
+
+{
+    "authority": "https://login.microsoftonline.com/organizations",
+    "client_id": "your_client_id",
+    "scope": ["User.ReadBasic.All"],
+        // You can find the other permission names from this document
+        // https://docs.microsoft.com/en-us/graph/permissions-reference
+}
+
+You can then run this sample with a JSON configuration file:
+
+    python sample.py parameters.json
+"""
+
+import sys  # For simplicity, we'll read config file from 1st CLI param sys.argv[1]
+import json
+import logging
+
+import msal
+
+
+# Optional logging
+# logging.basicConfig(level=logging.DEBUG)  # Enable DEBUG log for entire script
+# logging.getLogger("msal").setLevel(logging.INFO)  # Optionally disable MSAL DEBUG logs
+
+config = json.load(open(sys.argv[1]))
+
+def get_rt_via_old_app():
+    # Let's pretend this is an old app powered by ADAL
+    app = msal.PublicClientApplication(
+        config["client_id"], authority=config["authority"])
+    flow = app.initiate_device_flow(scopes=config["scope"])
+    if "user_code" not in flow:
+        raise ValueError(
+            "Fail to create device flow. Err: %s" % json.dumps(flow, indent=4))
+    print(flow["message"])
+    sys.stdout.flush()  # Some terminal needs this to ensure the message is shown
+
+    # Ideally you should wait here, in order to save some unnecessary polling
+    # input("Press Enter after signing in from another device to proceed, CTRL+C to abort.")
+
+    result = app.acquire_token_by_device_flow(flow)  # By default it will block
+    assert "refresh_token" in result, "We should have a successful result"
+    return result["refresh_token"]
+
+try:  # For easier testing, we try to reload a RT from previous run
+    old_rt = json.load(open("rt.json"))[0]
+except:  # If that is not possible, we acquire a RT
+    old_rt = get_rt_via_old_app()
+    json.dump([old_rt], open("rt.json", "w"))
+
+# Now we will try to migrate this old_rt into a new app powered by MSAL
+
+token_cache = msal.SerializableTokenCache()
+assert token_cache.serialize() == '{}', "Token cache is initially empty"
+app = msal.PublicClientApplication(
+    config["client_id"], authority=config["authority"], token_cache=token_cache)
+result = app.import_refresh_token(old_rt, config["scope"])
+if "error" in result:
+    print("Migration unsuccessful. Error: ", json.dumps(result, indent=2))
+else:
+    print("Migration is successful")
+    logging.debug("Token cache contains: %s", token_cache.serialize())
+
+# From now on, the RT is saved inside MSAL's cache,
+# and becomes available in normal MSAL coding pattern. For example:
+accounts = app.get_accounts()
+if accounts:
+    account = accounts[0]  # Assuming end user pick this account
+    result = app.acquire_token_silent(config["scope"], account)
+    if "access_token" in result:
+        print("RT is available in MSAL's cache, and can be used to acquire new AT")
+


### PR DESCRIPTION
This PR proposes an experimental API for migrating refresh token (RT) from other source (typically ADAL Python, but not necessarily only ADAL Python) to MSAL Python.

TL;DR: This PR proposes an `import_refresh_token(old_rt_string, scope_list)` as first-class citizen (i.e. not hiding from main API). As hinted by its name, its successful return value contains no RT, not even AT, not currently return an ID token (this one is TBD).

```python
app = msal.PublicClientApplication(
    "client_id", authority="https://login.microsoftonline.com/...", token_cache=...)

# NEW API
result = app.import_refresh_token(old_rt, ["scope1", "scope2"])  # <-- NEW API
if "error" in result:
    print("Migration unsuccessful. Error: ", json.dumps(result, indent=2))
else:
    print("Migration is successful")

# From now on, the RT is saved inside MSAL's cache,
# and becomes available in normal MSAL coding pattern. For example:
...
result = app.acquire_token_silent(["scope1"], ...)
```

So that there will be no way to (ab)use such migration API alone as a normal flow. The programming model would be to complete the RT migration upfront, and then come back to the normal MSAL coding model.

Reviewers can focus on its [usage pattern (highlighted at the bottom of this page)](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/191/files#diff-615899d8b1282d9f785b5404cf87e0ccR60-R68), rather than its actual implementation.

Background:

1. To simplify token migration, we do not need to migrate existing access token (AT). We just need to migrate RTs. Because: (1) ATs are short-lived, old ATs might already been expired when the migration happens. (2) Once we have RTs migrated, they will be automatically used to obtain new ATs.
2. To migrate RTs, a shortcut is to use the old RT to redeem an AT, during such process, a new RT will typically also return, and then MSAL's existing token cache mechanism will kick in, and store the new RT and AT properly. This means to call an imaginary API roughly named as `acquire_token_by_refresh_token(...)`.
3. However, historically, ADAL/MSAL has been designed to downplay the RT concept.
   * Many MSALs do not provide an `acquire_token_by_refresh_token(rt, scope, ...)` API. Instead, MSALs provide a higher level API `acquire_token_silent(scope, ...)` which uses RT from internal cache. For example, [MSAL .Net only provides `AcquireTokenByRefreshToken(...)` in an indirect way](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Adal-to-Msal#adalnet-v2x-migration-to-msalnet-v3x):
      > As this method is intended for scenarios that are not typical, it is not readily accessible with the IConfidentialClientApplication without first casting it to IByRefreshToken.
      > You will see an access token and ID token returned in your AuthenticationResult while your new refresh token is stored in the cache.

     But, even so, an `AcquireTokenByRefreshToken()` is arguably still provided and documented, and it can be used to acquire AT.

   * MSAL Java provides `AcquireTokenByRefreshToken(...)` out-of-the-box. It returns no RT, either, but it returns AT, etc..
