### PR TITLE
One of the examples in the README was not legal python syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There will be some variations for different flows. They are demonstrated in
    from msal import PublicClientApplication
    app = PublicClientApplication(
        "your_client_id",
-       "authority": "https://login.microsoftonline.com/Enter_the_Tenant_Name_Here")
+       authority="https://login.microsoftonline.com/Enter_the_Tenant_Name_Here")
    ```
 
    Later, each time you would want an access token, you start by:


### PR DESCRIPTION
I updated the example to match what the source seems to want.


