### PR TITLE
Revert "Application initializer does not make tenant discovery calls (It was PR 205)"

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -198,9 +198,8 @@ class ClientApplication(object):
                 authority or "https://login.microsoftonline.com/common/",
                 self.http_client, validate_authority=validate_authority)
             # Here the self.authority is not the same type as authority in input
-        self.client = None
         self.token_cache = token_cache or TokenCache()
-        self._client_credential = client_credential
+        self.client = self._build_client(client_credential, self.authority)
         self.authority_groups = None
 
     def _build_client(self, client_credential, authority):
@@ -248,12 +247,6 @@ class ClientApplication(object):
             on_obtaining_tokens=self.token_cache.add,
             on_removing_rt=self.token_cache.remove_rt,
             on_updating_rt=self.token_cache.update_rt)
-
-    def _get_client(self):
-        if not self.client:
-            self.authority.initialize()
-            self.client = self._build_client(self._client_credential, self.authority)
-        return self.client
 
     def get_authorization_request_url(
             self,
@@ -314,7 +307,6 @@ class ClientApplication(object):
             authority,
             self.http_client
             ) if authority else self.authority
-        the_authority.initialize()
 
         client = Client(
             {"authorization_endpoint": the_authority.authorization_endpoint},
@@ -375,7 +367,7 @@ class ClientApplication(object):
         # really empty.
         assert isinstance(scopes, list), "Invalid parameter type"
         self._validate_ssh_cert_input_data(kwargs.get("data", {}))
-        return self._get_client().obtain_token_by_authorization_code(
+        return self.client.obtain_token_by_authorization_code(
             code, redirect_uri=redirect_uri,
             scope=decorate_scope(scopes, self.client_id),
             headers={
@@ -399,7 +391,6 @@ class ClientApplication(object):
             Your app can choose to display those information to end user,
             and allow user to choose one of his/her accounts to proceed.
         """
-        self.authority.initialize()
         accounts = self._find_msal_accounts(environment=self.authority.instance)
         if not accounts:  # Now try other aliases of this authority instance
             for alias in self._get_authority_aliases(self.authority.instance):
@@ -552,7 +543,6 @@ class ClientApplication(object):
         #     authority,
         #     self.http_client,
         #     ) if authority else self.authority
-        self.authority.initialize()
         result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
             scopes, account, self.authority, force_refresh=force_refresh,
             correlation_id=correlation_id,
@@ -565,7 +555,6 @@ class ClientApplication(object):
                 "https://" + alias + "/" + self.authority.tenant,
                 self.http_client,
                 validate_authority=False)
-            the_authority.initialize()
             result = self._acquire_token_silent_from_cache_and_possibly_refresh_it(
                 scopes, account, the_authority, force_refresh=force_refresh,
                 correlation_id=correlation_id,
@@ -735,7 +724,7 @@ class ClientApplication(object):
             * A dict contains "error" and some other keys, when error happened.
             * A dict contains no "error" key means migration was successful.
         """
-        return self._get_client().obtain_token_by_refresh_token(
+        return self.client.obtain_token_by_refresh_token(
             refresh_token,
             scope=decorate_scope(scopes, self.client_id),
             rt_getter=lambda rt: rt,
@@ -766,7 +755,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
             - an error response would contain some other readable key/value pairs.
         """
         correlation_id = _get_new_correlation_id()
-        flow = self._get_client().initiate_device_flow(
+        flow = self.client.initiate_device_flow(
             scope=decorate_scope(scopes or [], self.client_id),
             headers={
                 CLIENT_REQUEST_ID: correlation_id,
@@ -790,7 +779,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
             - A successful response would contain "access_token" key,
             - an error response would contain "error" and usually "error_description".
         """
-        return self._get_client().obtain_token_by_device_flow(
+        return self.client.obtain_token_by_device_flow(
             flow,
             data=dict(kwargs.pop("data", {}), code=flow["device_code"]),
                 # 2018-10-4 Hack:
@@ -827,7 +816,6 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
             CLIENT_CURRENT_TELEMETRY: _build_current_telemetry_request_header(
                 self.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD_ID),
             }
-        self.authority.initialize()
         if not self.authority.is_adfs:
             user_realm_result = self.authority.user_realm_discovery(
                 username, correlation_id=headers[CLIENT_REQUEST_ID])
@@ -835,7 +823,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
                 return self._acquire_token_by_username_password_federated(
                     user_realm_result, username, password, scopes=scopes,
                     headers=headers, **kwargs)
-        return self._get_client().obtain_token_by_username_password(
+        return self.client.obtain_token_by_username_password(
                 username, password, scope=scopes,
                 headers=headers,
                 **kwargs)
@@ -864,16 +852,16 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
         GRANT_TYPE_SAML1_1 = 'urn:ietf:params:oauth:grant-type:saml1_1-bearer'
         grant_type = {
             SAML_TOKEN_TYPE_V1: GRANT_TYPE_SAML1_1,
-            SAML_TOKEN_TYPE_V2: Client.GRANT_TYPE_SAML2,
+            SAML_TOKEN_TYPE_V2: self.client.GRANT_TYPE_SAML2,
             WSS_SAML_TOKEN_PROFILE_V1_1: GRANT_TYPE_SAML1_1,
-            WSS_SAML_TOKEN_PROFILE_V2: Client.GRANT_TYPE_SAML2
+            WSS_SAML_TOKEN_PROFILE_V2: self.client.GRANT_TYPE_SAML2
             }.get(wstrust_result.get("type"))
         if not grant_type:
             raise RuntimeError(
                 "RSTR returned unknown token type: %s", wstrust_result.get("type"))
-        Client.grant_assertion_encoders.setdefault(  # Register a non-standard type
-            grant_type, Client.encode_saml_assertion)
-        return self._get_client().obtain_token_by_assertion(
+        self.client.grant_assertion_encoders.setdefault(  # Register a non-standard type
+            grant_type, self.client.encode_saml_assertion)
+        return self.client.obtain_token_by_assertion(
             wstrust_result["token"], grant_type, scope=scopes, **kwargs)
 
 
@@ -891,7 +879,7 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
             - an error response would contain "error" and usually "error_description".
         """
         # TBD: force_refresh behavior
-        return self._get_client().obtain_token_for_client(
+        return self.client.obtain_token_for_client(
             scope=scopes,  # This grant flow requires no scope decoration
             headers={
                 CLIENT_REQUEST_ID: _get_new_correlation_id(),
@@ -923,9 +911,9 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
         """
         # The implementation is NOT based on Token Exchange
         # https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-16
-        return self._get_client().obtain_token_by_assertion(  # bases on assertion RFC 7521
+        return self.client.obtain_token_by_assertion(  # bases on assertion RFC 7521
             user_assertion,
-            Client.GRANT_TYPE_JWT,  # IDTs and AAD ATs are all JWTs
+            self.client.GRANT_TYPE_JWT,  # IDTs and AAD ATs are all JWTs
             scope=decorate_scope(scopes, self.client_id),  # Decoration is used for:
                 # 1. Explicitly requesting an RT, without relying on AAD default
                 #    behavior, even though it currently still issues an RT.

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -53,17 +53,6 @@ class Authority(object):
             performed.
         """
         self._http_client = http_client
-        self._authority_url = authority_url
-        self._validate_authority = validate_authority
-        self._is_initialized = False
-
-    def initialize(self):
-        if not self._is_initialized:
-            self.__initialize(self._authority_url, self._http_client, self._validate_authority)
-            self._is_initialized = True
-
-    def __initialize(self, authority_url, http_client, validate_authority):
-        self._http_client = http_client
         authority, self.instance, tenant = canonicalize(authority_url)
         parts = authority.path.split('/')
         is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or (

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -104,7 +104,6 @@ class TestClientApplicationAcquireTokenSilentFociBehaviors(unittest.TestCase):
         self.authority_url = "https://login.microsoftonline.com/common"
         self.authority = msal.authority.Authority(
             self.authority_url, MinimalHttpClient())
-        self.authority.initialize()
         self.scopes = ["s1", "s2"]
         self.uid = "my_uid"
         self.utid = "my_utid"

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -13,7 +13,6 @@ class TestAuthority(unittest.TestCase):
         for host in WELL_KNOWN_AUTHORITY_HOSTS:
             a = Authority(
                 'https://{}/common'.format(host), MinimalHttpClient())
-            a.initialize()
             self.assertEqual(
                 a.authorization_endpoint,
                 'https://%s/common/oauth2/v2.0/authorize' % host)
@@ -35,7 +34,7 @@ class TestAuthority(unittest.TestCase):
         _assert = getattr(self, "assertRaisesRegex", self.assertRaisesRegexp)  # Hack
         with _assert(ValueError, "invalid_instance"):
             Authority('https://example.com/tenant_doesnt_matter_in_this_case',
-                      MinimalHttpClient()).initialize()
+                      MinimalHttpClient())
 
     def test_invalid_host_skipping_validation_can_be_turned_off(self):
         try:
@@ -86,7 +85,7 @@ class TestAuthorityInternalHelperUserRealmDiscovery(unittest.TestCase):
         authority = "https://login.microsoftonline.com/common"
         self.assertNotIn(authority, Authority._domains_without_user_realm_discovery)
         a = Authority(authority, MinimalHttpClient(), validate_authority=False)
-        a.initialize()
+
         # We now pretend this authority supports no User Realm Discovery
         class MockResponse(object):
             status_code = 404

--- a/tests/test_authority_patch.py
+++ b/tests/test_authority_patch.py
@@ -15,7 +15,6 @@ class TestAuthorityHonorsPatchedRequests(unittest.TestCase):
         # First, we test that the original, unmodified authority is working
         a = msal.authority.Authority(
             "https://login.microsoftonline.com/common", MinimalHttpClient())
-        a.initialize()
         self.assertEqual(
             a.authorization_endpoint,
             'https://login.microsoftonline.com/common/oauth2/v2.0/authorize')
@@ -28,7 +27,6 @@ class TestAuthorityHonorsPatchedRequests(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 a = msal.authority.Authority(
                     "https://login.microsoftonline.com/common", MinimalHttpClient())
-                a.initialize()
         finally:  # Tricky:
             # Unpatch is necessary otherwise other test cases would be affected
             msal.authority.requests = original


### PR DESCRIPTION
This reverts commit 8d62027c9067a05a4c4d482bf659e1411f2a37f2 i.e. #205 , which turns out breaks [Azure SDK's current monkeypatch](https://github.com/Azure/azure-sdk-for-python/blob/230afcfb50cea823d0fb23df75d740149ba5a503/sdk/identity/azure-identity/azure/identity/_internal/msal_credentials.py#L135).

We now choose to revert this "lazy authority" feature, and then release a MSAL 1.4.1 asap, before existing Azure SDK customers hitting this. We will re-introduce the "lazy authority" feature at a later time, after Azure SDK's next release removing that monkeypatch.