### PR TITLE
Adding test case for acquire_token_silent in Arlington

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -552,6 +552,12 @@ class ClientApplication(object):
             return result
         final_result = result
         for alias in self._get_authority_aliases(self.authority.instance):
+            if not self.token_cache.find(
+                    self.token_cache.CredentialType.REFRESH_TOKEN,
+                    target=scopes,
+                    query={"environment": alias}):
+                # Skip heavy weight logic when RT for this alias doesn't exist
+                continue
             the_authority = Authority(
                 "https://" + alias + "/" + self.authority.tenant,
                 self.http_client,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -590,6 +590,17 @@ class ArlingtonCloudTestCase(LabBasedTestCase):
         config["scope"] = ["user.read"]
         self._test_device_flow(**config)
 
+    def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
+        config = self.get_lab_user(
+            usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        app = msal.ConfidentialClientApplication(
+            config['client_id'], authority=config['authority'],
+            http_client=MinimalHttpClient())
+        result = app.acquire_token_silent(scopes=config['scope'], account=None)
+        self.assertEqual(result, None)
+        # Note: An alias in this region is no longer accepting HTTPS traffic.
+        #       If this test case passes without exception,
+        #       it means MSAL Python is not affected by that.
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a test case to reproduce the error found in #223. It is expected to fail right now. 