### PR TITLE
Removing content type header for GET requests to Mex endpoint

### DIFF
--- a/msal/mex.py
+++ b/msal/mex.py
@@ -41,8 +41,7 @@ def _xpath_of_root(route_to_leaf):
 
 
 def send_request(mex_endpoint, http_client, **kwargs):
-    mex_document = http_client.get(
-        mex_endpoint, **kwargs).text
+    mex_document = http_client.get(mex_endpoint, **kwargs).text
     return Mex(mex_document).get_wstrust_username_password_endpoint()
 
 

--- a/msal/mex.py
+++ b/msal/mex.py
@@ -42,8 +42,7 @@ def _xpath_of_root(route_to_leaf):
 
 def send_request(mex_endpoint, http_client, **kwargs):
     mex_document = http_client.get(
-        mex_endpoint, headers={'Content-Type': 'application/soap+xml'},
-        **kwargs).text
+        mex_endpoint, **kwargs).text
     return Mex(mex_document).get_wstrust_username_password_endpoint()
 
 


### PR DESCRIPTION
Closes #226 
- Content-type is not needed for Http GET requests
- Verified its not used in [MSAL .NET](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/master/src/client/Microsoft.Identity.Client/WsTrust/WsTrustWebRequestManager.cs#L34) implementation or [MSAL Java](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/ca87b927f249f7dd00bb422be255137409cbe492/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java#L80) implementation.