### PR TITLE
MSAL Python 1.4.3

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -21,7 +21,7 @@ from .token_cache import TokenCache
 
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
* Bugfix: A regression in previous release causing MSAL to not able to read some tokens from a different authority alias (#235, #236)