### PR TITLE
Blackforest and fairfax migration

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -612,6 +612,12 @@ class BlackForestCloudTestCase(LabBasedTestCase):
         config['authority'] = "https://login.microsoftonline.de/organizations"
         self._test_username_password(**config)
 
+    def test_acquire_token_ropc_federated_user(self):
+        config = self.get_lab_user(azureenvironment=self.environment, usertype="federated")
+        config["password"] = self.get_lab_user_secret("BLFMSIDLAB")
+        config['authority'] = "https://login.microsoftonline.de/organizations"
+        self._test_username_password(**config)
+
     def test_acquire_token_by_client_secret(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
         config["client_secret"] = self.get_lab_user_secret("BLFMSIDLAB-IDLABS-APP-CC")
@@ -666,6 +672,12 @@ class FairfaxCloudTestCase(LabBasedTestCase):
         config = self.get_lab_user(azureenvironment=self.environment)
         config["password"] = self.get_lab_user_secret("FFXMSIDLAB")
         config["authority"] = "https://login.microsoftonline.us/organizations"
+        self._test_username_password(**config)
+
+    def test_acquire_token_ropc_federated_user(self):
+        config = self.get_lab_user(azureenvironment=self.environment, usertype="federated")
+        config["password"] = self.get_lab_user_secret("FFXMSIDLAB")
+        config['authority'] = "https://login.microsoftonline.us/organizations"
         self._test_username_password(**config)
 
     def test_acquire_token_by_client_secret(self):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -617,6 +617,7 @@ class BlackForestCloudTestCase(LabBasedTestCase):
         config["client_secret"] = self.get_lab_user_secret("BLFMSIDLAB-IDLABS-APP-CC")
         self._test_acquire_token_by_client_secret(**config)
 
+    @unittest.skipIf(os.getenv("TRAVIS"), "Skip device flow for now")
     def test_acquire_token_device_flow(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config["scope"] = ["user.read"]
@@ -650,6 +651,7 @@ class FairfaxCloudTestCase(LabBasedTestCase):
         config["client_secret"] = self.get_lab_user_secret("FFXMSIDLAB-IDLABS-APP-Confidential-Client")
         self._test_acquire_token_by_client_secret(**config)
 
+    @unittest.skipIf(os.getenv("TRAVIS"), "Skip device flow for now")
     def test_acquire_token_device_flow(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config["scope"] = ["user.read"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -602,6 +602,73 @@ class ArlingtonCloudTestCase(LabBasedTestCase):
         #       If this test case passes without exception,
         #       it means MSAL Python is not affected by that.
 
+
+class BlackForestCloudTestCase(LabBasedTestCase):
+    environment = "azuregermanycloudmigrated"
+
+    def test_acquire_token_by_ropc(self):
+        config = self.get_lab_user(azureenvironment=self.environment)
+        config["password"] = self.get_lab_user_secret("BLFMSIDLAB")
+        config['authority'] = "https://login.microsoftonline.de/organizations"
+        self._test_username_password(**config)
+
+    def test_acquire_token_by_client_secret(self):
+        config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        config["client_secret"] = self.get_lab_user_secret("BLFMSIDLAB-IDLABS-APP-CC")
+        self._test_acquire_token_by_client_secret(**config)
+
+    def test_acquire_token_device_flow(self):
+        config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
+        config["scope"] = ["user.read"]
+        config['authority'] = "https://login.microsoftonline.de/organizations"
+        self._test_device_flow(**config)
+
+    def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
+        config = self.get_lab_user(
+            usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        app = msal.ConfidentialClientApplication(
+            config['client_id'], authority=config['authority'],
+            http_client=MinimalHttpClient())
+        result = app.acquire_token_silent(scopes=config['scope'], account=None)
+        self.assertEqual(result, None)
+        # Note: An alias in this region is no longer accepting HTTPS traffic.
+        #       If this test case passes without exception,
+        #       it means MSAL Python is not affected by that.
+
+
+class FairfaxCloudTestCase(LabBasedTestCase):
+    environment = "azureusgovernmentmigrated"
+
+    def test_acquire_token_by_ropc(self):
+        config = self.get_lab_user(azureenvironment=self.environment)
+        config["password"] = self.get_lab_user_secret("FFXMSIDLAB")
+        config["authority"] = "https://login.microsoftonline.us/organizations"
+        self._test_username_password(**config)
+
+    def test_acquire_token_by_client_secret(self):
+        config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        config["client_secret"] = self.get_lab_user_secret("FFXMSIDLAB-IDLABS-APP-Confidential-Client")
+        self._test_acquire_token_by_client_secret(**config)
+
+    def test_acquire_token_device_flow(self):
+        config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
+        config["scope"] = ["user.read"]
+        config["authority"] = "https://login.microsoftonline.us/organizations"
+        self._test_device_flow(**config)
+
+    def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
+        config = self.get_lab_user(
+            usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        app = msal.ConfidentialClientApplication(
+            config['client_id'], authority=config['authority'],
+            http_client=MinimalHttpClient())
+        result = app.acquire_token_silent(scopes=config['scope'], account=None)
+        self.assertEqual(result, None)
+        # Note: An alias in this region is no longer accepting HTTPS traffic.
+        #       If this test case passes without exception,
+        #       it means MSAL Python is not affected by that.
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -364,7 +364,9 @@ class LabBasedTestCase(E2eTestCase):
         result = resp.json()[0]
         _env = query.get("azureenvironment", "").lower()
         authority_base = {
-            "azureusgovernment": "https://login.microsoftonline.us/"
+            "azureusgovernment": "https://login.microsoftonline.us/",
+            "azuregermanycloudmigrated": "https://login.microsoftonline.de/",
+            "azureusgovernmentmigrated": "https://login.microsoftonline.us/"
             }.get(_env, "https://login.microsoftonline.com/")
         scope = {
             "azureusgovernment": ["https://graph.microsoft.us/.default"],
@@ -609,13 +611,11 @@ class BlackForestCloudTestCase(LabBasedTestCase):
     def test_acquire_token_by_ropc(self):
         config = self.get_lab_user(azureenvironment=self.environment)
         config["password"] = self.get_lab_user_secret("BLFMSIDLAB")
-        config['authority'] = "https://login.microsoftonline.de/organizations"
         self._test_username_password(**config)
 
     def test_acquire_token_ropc_federated_user(self):
         config = self.get_lab_user(azureenvironment=self.environment, usertype="federated")
         config["password"] = self.get_lab_user_secret("BLFMSIDLAB")
-        config['authority'] = "https://login.microsoftonline.de/organizations"
         self._test_username_password(**config)
 
     def test_acquire_token_by_client_secret(self):
@@ -626,7 +626,6 @@ class BlackForestCloudTestCase(LabBasedTestCase):
     def test_acquire_token_device_flow(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config["scope"] = ["user.read"]
-        config['authority'] = "https://login.microsoftonline.de/organizations"
         self._test_device_flow(**config)
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
@@ -638,19 +637,18 @@ class BlackForestCloudTestCase(LabBasedTestCase):
         password="***"  # From https://aka.ms/GetLabUserSecret?Secret=BLFMSIDLAB
         """
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
-        config["authority"] = "https://login.microsoftonline.de/organizations"
         config["port"] = 8080
         self._test_acquire_token_by_auth_code(**config)
 
     def test_acquire_token_obo(self):
         config_cca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
         config_cca["client_secret"] = self.get_lab_user_secret("BLFMSIDLAB-IDLABS-APP-CC")
-        config_cca["authority"] = "https://login.microsoftonline.de/organizations"
 
         config_pca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config_pca["password"] = self.get_lab_user_secret("BLFMSIDLAB")
-        config_pca["scope"] = ["https://lab1.blfmsidlab.de/IDLABS_APP_CC/user_impersonation"]
-        config_pca["authority"] = "https://login.microsoftonline.de/organizations"
+        config_pca["scope"] = ["https://TESTTESTIDTEST53.onmicrosoft.de/1c4998ba-7dd7-4ae0-8241-475165ce2ce1/user_impersonation"]
+
+        self._test_acquire_token_obo(config_pca, config_cca)
 
     def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
         config = self.get_lab_user(
@@ -671,13 +669,11 @@ class FairfaxCloudTestCase(LabBasedTestCase):
     def test_acquire_token_by_ropc(self):
         config = self.get_lab_user(azureenvironment=self.environment)
         config["password"] = self.get_lab_user_secret("FFXMSIDLAB")
-        config["authority"] = "https://login.microsoftonline.us/organizations"
         self._test_username_password(**config)
 
     def test_acquire_token_ropc_federated_user(self):
         config = self.get_lab_user(azureenvironment=self.environment, usertype="federated")
         config["password"] = self.get_lab_user_secret("FFXMSIDLAB")
-        config['authority'] = "https://login.microsoftonline.us/organizations"
         self._test_username_password(**config)
 
     def test_acquire_token_by_client_secret(self):
@@ -688,7 +684,6 @@ class FairfaxCloudTestCase(LabBasedTestCase):
     def test_acquire_token_device_flow(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config["scope"] = ["user.read"]
-        config["authority"] = "https://login.microsoftonline.us/4f9098e2-ab9e-43b7-9e68-9e52d645b781"
         self._test_device_flow(**config)
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
@@ -700,19 +695,16 @@ class FairfaxCloudTestCase(LabBasedTestCase):
         password="***"  # From https://aka.ms/GetLabUserSecret?Secret=FFXMSIDLAB
         """
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
-        config["authority"] = "https://login.microsoftonline.us/organizations"
         config["port"] = 8080
         self._test_acquire_token_by_auth_code(**config)
 
     def test_acquire_token_obo(self):
         config_cca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
         config_cca["client_secret"] = self.get_lab_user_secret("FFXMSIDLAB-IDLABS-APP-Confidential-Client")
-        config_cca["authority"] = "https://login.microsoftonline.us/organizations"
 
         config_pca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config_pca["password"] = self.get_lab_user_secret("FFXMSIDLAB")
         config_pca["scope"] = ["https://lab1.ffxmsidlab.us/IDLABS_APP_Confidential_Client/files.read"]
-        config_pca["authority"] = "https://login.microsoftonline.us/organizations"
 
         self._test_acquire_token_obo(config_pca, config_cca)
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -637,6 +637,16 @@ class BlackForestCloudTestCase(LabBasedTestCase):
         config["port"] = 8080
         self._test_acquire_token_by_auth_code(**config)
 
+    def test_acquire_token_obo(self):
+        config_cca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        config_cca["client_secret"] = self.get_lab_user_secret("BLFMSIDLAB-IDLABS-APP-CC")
+        config_cca["authority"] = "https://login.microsoftonline.de/organizations"
+
+        config_pca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
+        config_pca["password"] = self.get_lab_user_secret("BLFMSIDLAB")
+        config_pca["scope"] = ["https://lab1.blfmsidlab.de/IDLABS_APP_CC/user_impersonation"]
+        config_pca["authority"] = "https://login.microsoftonline.de/organizations"
+
     def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
         config = self.get_lab_user(
             usertype="cloud", azureenvironment=self.environment, publicClient="no")
@@ -683,6 +693,18 @@ class FairfaxCloudTestCase(LabBasedTestCase):
         config["authority"] = "https://login.microsoftonline.us/organizations"
         config["port"] = 8080
         self._test_acquire_token_by_auth_code(**config)
+
+    def test_acquire_token_obo(self):
+        config_cca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="no")
+        config_cca["client_secret"] = self.get_lab_user_secret("FFXMSIDLAB-IDLABS-APP-Confidential-Client")
+        config_cca["authority"] = "https://login.microsoftonline.us/organizations"
+
+        config_pca = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
+        config_pca["password"] = self.get_lab_user_secret("FFXMSIDLAB")
+        config_pca["scope"] = ["https://lab1.ffxmsidlab.us/IDLABS_APP_Confidential_Client/files.read"]
+        config_pca["authority"] = "https://login.microsoftonline.us/organizations"
+
+        self._test_acquire_token_obo(config_pca, config_cca)
 
     def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
         config = self.get_lab_user(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -110,7 +110,7 @@ class E2eTestCase(unittest.TestCase):
         self.app = msal.PublicClientApplication(
             client_id, authority=authority, http_client=MinimalHttpClient())
         flow = self.app.initiate_device_flow(scopes=scope)
-        assert "user_code" in flow, "DF does not seem to be provisioned: %s".format(
+        assert "user_code" in flow, "DF does not seem to be provisioned: {}".format(
             json.dumps(flow, indent=4))
         logger.info(flow["message"])
 
@@ -617,7 +617,6 @@ class BlackForestCloudTestCase(LabBasedTestCase):
         config["client_secret"] = self.get_lab_user_secret("BLFMSIDLAB-IDLABS-APP-CC")
         self._test_acquire_token_by_client_secret(**config)
 
-    @unittest.skipIf(os.getenv("TRAVIS"), "Skip device flow for now")
     def test_acquire_token_device_flow(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config["scope"] = ["user.read"]
@@ -674,11 +673,10 @@ class FairfaxCloudTestCase(LabBasedTestCase):
         config["client_secret"] = self.get_lab_user_secret("FFXMSIDLAB-IDLABS-APP-Confidential-Client")
         self._test_acquire_token_by_client_secret(**config)
 
-    @unittest.skipIf(os.getenv("TRAVIS"), "Skip device flow for now")
     def test_acquire_token_device_flow(self):
         config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
         config["scope"] = ["user.read"]
-        config["authority"] = "https://login.microsoftonline.us/organizations"
+        config["authority"] = "https://login.microsoftonline.us/4f9098e2-ab9e-43b7-9e68-9e52d645b781"
         self._test_device_flow(**config)
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -624,6 +624,19 @@ class BlackForestCloudTestCase(LabBasedTestCase):
         config['authority'] = "https://login.microsoftonline.de/organizations"
         self._test_device_flow(**config)
 
+    @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
+    def test_acquire_token_by_auth_code(self):
+        """When prompted, you can manually login using this account:
+
+        # https://msidlab.com/api/user?azureEnvironment=azuregermanycloudmigrated
+        username = "..."  # The upn from the link above
+        password="***"  # From https://aka.ms/GetLabUserSecret?Secret=BLFMSIDLAB
+        """
+        config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
+        config["authority"] = "https://login.microsoftonline.de/organizations"
+        config["port"] = 8080
+        self._test_acquire_token_by_auth_code(**config)
+
     def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
         config = self.get_lab_user(
             usertype="cloud", azureenvironment=self.environment, publicClient="no")
@@ -657,6 +670,19 @@ class FairfaxCloudTestCase(LabBasedTestCase):
         config["scope"] = ["user.read"]
         config["authority"] = "https://login.microsoftonline.us/organizations"
         self._test_device_flow(**config)
+
+    @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
+    def test_acquire_token_by_auth_code(self):
+        """When prompted, you can manually login using this account:
+
+        # https://msidlab.com/api/user?azureEnvironment=azureusgovernmentmigrated
+        username = "..."  # The upn from the link above
+        password="***"  # From https://aka.ms/GetLabUserSecret?Secret=FFXMSIDLAB
+        """
+        config = self.get_lab_user(usertype="cloud", azureenvironment=self.environment, publicClient="yes")
+        config["authority"] = "https://login.microsoftonline.us/organizations"
+        config["port"] = 8080
+        self._test_acquire_token_by_auth_code(**config)
 
     def test_acquire_token_silent_with_an_empty_cache_should_return_none(self):
         config = self.get_lab_user(


### PR DESCRIPTION
Creating a rough PR to automate these scenarios before the labs migrate.
Observations:
Using organizations in the authority for Black forest device code flow works fine however Fairfax returns the following error:
```
"error": "invalid_request",
    "error_description": "AADSTS50059: No tenant-identifying information found in either the request or implied by any provided credentials.\r\nTrace ID: db673171-ef7e-4ee6-9a97-ce58e1210100\r\nCorrelation ID: c5499c80-a5e6-4105-a004-f2e6dfd176dd\r\nTimestamp: 2020-08-22 00:23:41Z",
    "error_codes": [
        50059
    ],
    "timestamp": "2020-08-22 00:23:41Z",
    "trace_id": "db673171-ef7e-4ee6-9a97-ce58e1210100",
    "correlation_id": "c5499c80-a5e6-4105-a004-f2e6dfd176dd",
    "interval": 5,
    "expires_in": 1800,
    "expires_at": 1598057621.564137,
    "_correlation_id": "c5499c80-a5e6-4105-a004-f2e6dfd176dd"
}
```
