### PR TITLE
Cache tokens by specified environment, not by OIDC Discovery

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -246,7 +246,8 @@ class ClientApplication(object):
             default_body=default_body,
             client_assertion=client_assertion,
             client_assertion_type=client_assertion_type,
-            on_obtaining_tokens=self.token_cache.add,
+            on_obtaining_tokens=lambda event: self.token_cache.add(dict(
+                event, environment=authority.instance)),
             on_removing_rt=self.token_cache.remove_rt,
             on_updating_rt=self.token_cache.update_rt)
 

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -126,6 +126,8 @@ class TokenCache(object):
         environment = realm = None
         if "token_endpoint" in event:
             _, environment, realm = canonicalize(event["token_endpoint"])
+        if "environment" in event:  # Always available unless in legacy test cases
+            environment = event["environment"]  # Set by application.py
         response = event.get("response", {})
         data = event.get("data", {})
         access_token = response.get("access_token")


### PR DESCRIPTION
@abhidnya13 please help verify this, both by re-running our BF/FF manual tests, and by code review, to see whether this can address the issue we found recently.