### PR TITLE
Changes in client capabilities as per AzCLI feedback

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1010,7 +1010,7 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
             The claims_challenge parameter requests specific claims requested by the resource provider
             in the form of a claims_challenge directive in the www-authenticate header to be
             returned from the UserInfo Endpoint and/or in the ID Token and/or Access Token.
-            It is a string of a JSON object which contains lists of claims being requested from these locations..
+            It is a string of a JSON object which contains lists of claims being requested from these locations.
 
         :return: A dict representing the json response from AAD:
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -272,10 +272,10 @@ class TestClientApplicationForAuthorityMigration(unittest.TestCase):
 class TestApplicationForClientCapabilities(unittest.TestCase):
 
     def test_capabilities_and_id_token_claims_merge(self):
-        client_capabilities = ["llt", "ssm"]
+        client_capabilities = ["foo", "bar"]
         claims_challenge = '''{"id_token": {"auth_time": {"essential": true}}}'''
         merged_claims = '''{"id_token": {"auth_time": {"essential": true}}, 
-                        "access_token": {"xms_cc": {"values": ["llt", "ssm"]}}}'''
+                        "access_token": {"xms_cc": {"values": ["foo", "bar"]}}}'''
         # Comparing  dictionaries as JSON object order differs based on python version
         self.assertEqual(
             json.loads(merged_claims),
@@ -283,12 +283,12 @@ class TestApplicationForClientCapabilities(unittest.TestCase):
                 client_capabilities, claims_challenge)))
 
     def test_capabilities_and_id_token_claims_and_access_token_claims_merge(self):
-        client_capabilities = ["llt", "ssm"]
+        client_capabilities = ["foo", "bar"]
         claims_challenge = '''{"id_token": {"auth_time": {"essential": true}}, 
                  "access_token": {"nbf":{"essential":true, "value":"1563308371"}}}'''
         merged_claims = '''{"id_token": {"auth_time": {"essential": true}},
                         "access_token": {"nbf": {"essential": true, "value": "1563308371"},
-                                        "xms_cc": {"values": ["llt", "ssm"]}}}'''
+                                        "xms_cc": {"values": ["foo", "bar"]}}}'''
         # Comparing  dictionaries as JSON object order differs based on python version
         self.assertEqual(
             json.loads(merged_claims),
@@ -302,8 +302,8 @@ class TestApplicationForClientCapabilities(unittest.TestCase):
             json.loads(_merge_claims_challenge_and_capabilities(None, claims_challenge)))
 
     def test_only_client_capabilities_no_claims_merge(self):
-        client_capabilities = ["llt", "ssm"]
-        merged_claims = '''{"access_token": {"xms_cc": {"values": ["llt", "ssm"]}}}'''
+        client_capabilities = ["foo", "bar"]
+        merged_claims = '''{"access_token": {"xms_cc": {"values": ["foo", "bar"]}}}'''
         self.assertEqual(
             json.loads(merged_claims),
             json.loads(_merge_claims_challenge_and_capabilities(client_capabilities, None)))


### PR DESCRIPTION
- Removing an extra period
- Using `foo` and `bar` as mock client capability values to avoid confusion for developers.