### PR TITLE
Passing encrypted key as credential

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,16 @@ setup(
     install_requires=[
         'requests>=2.0.0,<3',
         'PyJWT[crypto]>=1.0.0,<2',
-        'six>=1.6',
-        'cryptography>=2.1.4'
+
+        'cryptography>=0.6,<4',
+            # load_pem_private_key() is available since 0.6
+            # https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#06---2014-09-29
+            #
+            # Not sure what should be used as an upper bound here
+            # https://github.com/pyca/cryptography/issues/5532
+            # We will go with "<4" for now, which is also what our another dependency,
+            # pyjwt, currently use.
+
     ]
 )
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,8 @@ setup(
     install_requires=[
         'requests>=2.0.0,<3',
         'PyJWT[crypto]>=1.0.0,<2',
+        'six>=1.6',
+        'cryptography>=2.1.4'
     ]
 )
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -39,6 +39,33 @@ class TestHelperExtractCerts(unittest.TestCase):  # It is used by SNI scenario
         self.assertEqual(["my_cert1", "my_cert2"], extract_certs(pem))
 
 
+class TestEncryptedKeyAsClientCredential(unittest.TestCase):
+    # Internally, we use serialization.load_pem_private_key() to load an encrypted private key with a passphrase
+    # This function takes in encrypted key in bytes and passphrase in bytes too
+    # Our code handles such a conversion, adding test cases to verify such a conversion is needed
+
+    def test_encyrpted_key_in_bytes_and_string_password_should_error(self):
+        private_key = b"""
+        -----BEGIN ENCRYPTED PRIVATE KEY-----
+        test_private_key
+        -----END ENCRYPTED PRIVATE KEY-----
+        """
+        with self.assertRaises(TypeError):
+            # Using a unicode string for Python 2 to identify it as a string and not default to bytes
+            serialization.load_pem_private_key(
+                private_key, password=u"string_password", backend=default_backend())
+
+    def test_encyrpted_key_is_string_and_bytes_password_should_error(self):
+        private_key = u"""
+        -----BEGIN ENCRYPTED PRIVATE KEY-----
+        test_private_key
+        -----END ENCRYPTED PRIVATE KEY-----
+        """
+        with self.assertRaises(TypeError):
+            serialization.load_pem_private_key(
+                private_key, password=b"byte_password", backend=default_backend())
+
+
 class TestClientApplicationAcquireTokenSilentErrorBehaviors(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,6 +1,7 @@
 # Note: Since Aug 2019 we move all e2e tests into test_e2e.py,
 # so this test_application file contains only unit tests without dependency.
 from msal.application import *
+from msal.application import _str2bytes
 import msal
 from msal.application import _merge_claims_challenge_and_capabilities
 from tests import unittest
@@ -39,31 +40,12 @@ class TestHelperExtractCerts(unittest.TestCase):  # It is used by SNI scenario
         self.assertEqual(["my_cert1", "my_cert2"], extract_certs(pem))
 
 
-class TestEncryptedKeyAsClientCredential(unittest.TestCase):
-    # Internally, we use serialization.load_pem_private_key() to load an encrypted private key with a passphrase
-    # This function takes in encrypted key in bytes and passphrase in bytes too
-    # Our code handles such a conversion, adding test cases to verify such a conversion is needed
+class TestBytesConversion(unittest.TestCase):
+    def test_string_to_bytes(self):
+        self.assertEqual(type(_str2bytes("some string")), type(b"bytes"))
 
-    def test_encyrpted_key_in_bytes_and_string_password_should_error(self):
-        private_key = b"""
-        -----BEGIN ENCRYPTED PRIVATE KEY-----
-        test_private_key
-        -----END ENCRYPTED PRIVATE KEY-----
-        """
-        with self.assertRaises(TypeError):
-            # Using a unicode string for Python 2 to identify it as a string and not default to bytes
-            serialization.load_pem_private_key(
-                private_key, password=u"string_password", backend=default_backend())
-
-    def test_encyrpted_key_is_string_and_bytes_password_should_error(self):
-        private_key = u"""
-        -----BEGIN ENCRYPTED PRIVATE KEY-----
-        test_private_key
-        -----END ENCRYPTED PRIVATE KEY-----
-        """
-        with self.assertRaises(TypeError):
-            serialization.load_pem_private_key(
-                private_key, password=b"byte_password", backend=default_backend())
+    def test_bytes_to_bytes(self):
+        self.assertEqual(type(_str2bytes(b"some bytes")), type(b"bytes"))
 
 
 class TestClientApplicationAcquireTokenSilentErrorBehaviors(unittest.TestCase):


### PR DESCRIPTION
Usage: We add one more optional field `passphrase` in the existing `client_credential` parameter of `ConfidentialClientApplication`. The docs will also be updated [here](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/270/files#diff-4d32d284fa6acf43894719eff11cb366e5969e0b61593bfd00c68a4cf9c441caR125-R136)