### PR TITLE
Fix a malfunction in yesterday's acquire_token_interactive() PR

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1059,9 +1059,11 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
                 port=port or 0),
             prompt=prompt,
             login_hint=login_hint,
-            domain_hint=domain_hint,
             timeout=timeout,
-            auth_params={"claims": claims},
+            auth_params={
+                "claims": claims,
+                "domain_hint": domain_hint,
+                },
             data=dict(kwargs.pop("data", {}), claims=claims),
             headers={
                 CLIENT_REQUEST_ID: _get_new_correlation_id(),

--- a/tests/http_client.py
+++ b/tests/http_client.py
@@ -10,11 +10,13 @@ class MinimalHttpClient:
         self.timeout = timeout
 
     def post(self, url, params=None, data=None, headers=None, **kwargs):
+        assert not kwargs, "Our stack shouldn't leak extra kwargs: %s" % kwargs
         return MinimalResponse(requests_resp=self.session.post(
             url, params=params, data=data, headers=headers,
             timeout=self.timeout))
 
     def get(self, url, params=None, headers=None, **kwargs):
+        assert not kwargs, "Our stack shouldn't leak extra kwargs: %s" % kwargs
         return MinimalResponse(requests_resp=self.session.get(
             url, params=params, headers=headers, timeout=self.timeout))
 


### PR DESCRIPTION
While working on a sample to demonstrate the newly-merged #260, we found a malfunction which prevented `acquire_token_interactive()` from functioning. So, a follow-up question would be, why the existing test automation did not catch that. Further investigation shows that, our previous test HttpClient was overly-flexible. Now both issues are fixed.

I'll commit the new sample in a different PR (so that it will be cleaner to be referenced).