### PR TITLE
Pass kwargs to acquire_token_by_refresh_token

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -942,7 +942,7 @@ class ClientApplication(object):
                     "you must include a string parameter named 'key_id' "
                     "which identifies the key in the 'req_cnf' argument.")
 
-    def acquire_token_by_refresh_token(self, refresh_token, scopes):
+    def acquire_token_by_refresh_token(self, refresh_token, scopes, **kwargs):
         """Acquire token(s) based on a refresh token (RT) obtained from elsewhere.
 
         You use this method only when you have old RTs from elsewhere,
@@ -965,6 +965,7 @@ class ClientApplication(object):
             * A dict contains "error" and some other keys, when error happened.
             * A dict contains no "error" key means migration was successful.
         """
+        self._validate_ssh_cert_input_data(kwargs.get("data", {}))
         return self.client.obtain_token_by_refresh_token(
             refresh_token,
             scope=decorate_scope(scopes, self.client_id),
@@ -976,6 +977,7 @@ class ClientApplication(object):
             rt_getter=lambda rt: rt,
             on_updating_rt=False,
             on_removing_rt=lambda rt_item: None,  # No OP
+            **kwargs
             )
 
 
@@ -1294,4 +1296,3 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
                     self.ACQUIRE_TOKEN_ON_BEHALF_OF_ID),
                 },
             **kwargs)
-

--- a/msal/application.py
+++ b/msal/application.py
@@ -977,8 +977,7 @@ class ClientApplication(object):
             rt_getter=lambda rt: rt,
             on_updating_rt=False,
             on_removing_rt=lambda rt_item: None,  # No OP
-            **kwargs
-            )
+            **kwargs)
 
 
 class PublicClientApplication(ClientApplication):  # browser app or mobile app


### PR DESCRIPTION
- Pass `kwargs` to `ClientApplication.acquire_token_by_refresh_token` so that `data` can be passed to `Client.obtain_token_by_refresh_token`.
- Call `_validate_ssh_cert_input_data` to make sure `data` is valid.

