### PR TITLE
Enable retry on connection error

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -241,6 +241,13 @@ class ClientApplication(object):
             # But you can patch that (https://github.com/psf/requests/issues/3341):
             self.http_client.request = functools.partial(
                 self.http_client.request, timeout=timeout)
+
+            # Enable a minimal retry. Better than nothing.
+            # https://github.com/psf/requests/blob/v2.25.1/requests/adapters.py#L94-L108
+            a = requests.adapters.HTTPAdapter(max_retries=1)
+            self.http_client.mount("http://", a)
+            self.http_client.mount("https://", a)
+
         self.app_name = app_name
         self.app_version = app_version
         self.authority = Authority(


### PR DESCRIPTION
The previous behavior is [the default behavior in requests, which does not retry at all](https://github.com/psf/requests/blob/v2.25.1/requests/adapters.py#L94-L108). Here we enable one retry. Too many retries could cause the application to hang for longer.

@jiasli What do you think?