### PR TITLE
Fix type hint for `client_credential`

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -120,7 +120,7 @@ class ClientApplication(object):
 
         :param str client_id: Your app has a client_id after you register it on AAD.
 
-        :param str client_credential:
+        :param Union[str, dict] client_credential:
             For :class:`PublicClientApplication`, you simply use `None` here.
             For :class:`ConfidentialClientApplication`,
             it can be a string containing client secret,
@@ -1343,4 +1343,3 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
             **kwargs))
         telemetry_context.update_telemetry(response)
         return response
-


### PR DESCRIPTION
PyCharm gives warning for the incorrect type hint:

![image](https://user-images.githubusercontent.com/4003950/113269465-0c95cf80-930b-11eb-8005-90423ff07f7d.png)
