### PR TITLE
Pass `on_obtaining_tokens` via `obtain_token_by_refresh_token`

### DIFF
--- a/msal/oauth2cli/oauth2.py
+++ b/msal/oauth2cli/oauth2.py
@@ -804,6 +804,7 @@ class Client(BaseClient):  # We choose to implement all 4 grants in 1 class
                 if not isinstance(token_item, string_types) else token_item,
             scope=scope,
             also_save_rt=on_updating_rt is False,
+            on_obtaining_tokens=on_obtaining_tokens,
             **kwargs)
         if resp.get('error') == 'invalid_grant':
             (on_removing_rt or self.on_removing_rt)(token_item)  # Discard old RT


### PR DESCRIPTION
## Symptom

While developing a PoC to solve #335, I noticed that `skip_account_creation` added by #262 never seems to make its way into `TokenCache.__add`.

`skip_account_creation` is assigned here and the lambda is passed to `obtain_token_by_refresh_token` via `on_obtaining_tokens`:

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/0f1ab8d5d97b3722776c2c661f6f083a26d1fec2/msal/application.py#L948-L957

However, `on_obtaining_tokens` is _discarded_ by `obtain_token_by_refresh_token`:

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/eb0a86fb6bf1b021ef58a872213ec88af86212d7/msal/oauth2cli/oauth2.py#L769-L813

## To Reproduce

1. Add a debug line 
   ```py
   print("__add:", realm, event.get("skip_account_creation"))
   ```
   before https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/31b24afe3eb6edd3af58bab40f1387be02cb389d/msal/token_cache.py#L178
2. Do multi-tenant auth with Azure CLI.
3. Verify the output is:
   ```
   __add: organizations None
   __add: 72f988bf-86f1-41af-91ab-2d7cd011db47 None
   __add: 246b1785-9030-40d8-a0f0-d94b15dc002c None
   __add: 2b8e6bbc-631a-4bf6-b0c6-d4947b3c79dd None
   __add: ca97aaa0-5a12-4ae3-8929-c8fb57dd93d6 None
   __add: 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a None
   ```
   `None` means `skip_account_creation` is not set.

## Change

After the change, the output is

```
__add: organizations None
__add: 72f988bf-86f1-41af-91ab-2d7cd011db47 True
__add: 246b1785-9030-40d8-a0f0-d94b15dc002c True
__add: 2b8e6bbc-631a-4bf6-b0c6-d4947b3c79dd True
__add: ca97aaa0-5a12-4ae3-8929-c8fb57dd93d6 True
__add: 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a True
```