### PR TITLE
Add ROPC support to Confidential Client

### DIFF
--- a/sample/username_password_sample.py
+++ b/sample/username_password_sample.py
@@ -34,8 +34,9 @@ import msal
 config = json.load(open(sys.argv[1]))
 
 # Create a preferably long-lived app instance which maintains a token cache.
-app = msal.PublicClientApplication(
+app = msal.ClientApplication(
     config["client_id"], authority=config["authority"],
+    client_credential=config.get("client_secret"),
     # token_cache=...  # Default cache is in memory only.
                        # You can learn how to use SerializableTokenCache from
                        # https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache


### PR DESCRIPTION
This resolves #294 .

This PR does the following things:

* Move ROPC from `PublicClientApplication` to its base, so that `ConfidentialClientApplication` would also have this feature
* Adding end-to-end test cases
* Also changes the built-in sample accordingly