### PR TITLE
Fix typo

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -602,7 +602,7 @@ class ClientApplication(object):
                         self._client_capabilities, claims_challenge)),
                 nonce=nonce,
                 **kwargs))
-            telemetry_context.update_telemetry(resposne)
+            telemetry_context.update_telemetry(response)
             return response
 
     def get_accounts(self, username=None):


### PR DESCRIPTION
This is a typo introduced in [this line](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/329/files#diff-4d32d284fa6acf43894719eff11cb366e5969e0b61593bfd00c68a4cf9c441caR605) from PR #329