### PR TITLE
Bring back docs for __init__()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,12 +35,16 @@ PublicClientApplication
    :members:
    :inherited-members:
 
+   .. automethod:: __init__
+
 ConfidentialClientApplication
 -----------------------------
 
 .. autoclass:: msal.ConfidentialClientApplication
    :members:
    :inherited-members:
+
+   .. automethod:: __init__
 
 TokenCache
 ----------


### PR DESCRIPTION
This addresses a [side effect](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/319/files#r609100105) of #319.