### PR TITLE
Reginal endpoint support

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -328,7 +328,12 @@ class ClientApplication(object):
         if region_to_use:
             logger.info('Region to be used: {}'.format(repr(region_to_use)))
             regional_host = ("{}.login.microsoft.com".format(region_to_use)
-                if central_authority.instance == "login.microsoftonline.com"
+                if central_authority.instance in (
+                    # The list came from https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/358/files#r629400328
+                    "login.microsoftonline.com",
+                    "login.windows.net",
+                    "sts.windows.net",
+                    )
                 else "{}.{}".format(region_to_use, central_authority.instance))
             return Authority(
                 "https://{}/{}".format(regional_host, central_authority.tenant),

--- a/msal/application.py
+++ b/msal/application.py
@@ -119,7 +119,7 @@ class ClientApplication(object):
             verify=True, proxies=None, timeout=None,
             client_claims=None, app_name=None, app_version=None,
             client_capabilities=None,
-            region=None,  # Note: We choose to add this param in this base class,
+            azure_region=None,  # Note: We choose to add this param in this base class,
                 # despite it is currently only needed by ConfidentialClientApplication.
                 # This way, it holds the same positional param place for PCA,
                 # when we would eventually want to add this feature to PCA in future.
@@ -229,7 +229,7 @@ class ClientApplication(object):
             `claims parameter <https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter`_
             which you will later provide via one of the acquire-token request.
 
-        :param str region:
+        :param str azure_region:
             Added since MSAL Python 1.12.0.
 
             As of 2021 May, regional service is only available for
@@ -301,7 +301,7 @@ class ClientApplication(object):
                 raise
 
         self.token_cache = token_cache or TokenCache()
-        self._region_configured = region
+        self._region_configured = azure_region
         self._region_detected = None
         self.client, self._regional_client = self._build_client(
             client_credential, self.authority)

--- a/msal/application.py
+++ b/msal/application.py
@@ -247,7 +247,8 @@ class ClientApplication(object):
             4. An app which already onboard to the region's allow-list.
 
             MSAL's default value is None, which means region behavior remains off.
-            If enabled, some of the MSAL traffic would remain inside that region.
+            If enabled, the `acquire_token_for_client()`-relevant traffic
+            would remain inside that region.
 
             App developer can opt in to a regional endpoint,
             by provide its region name, such as "westus", "eastus2".

--- a/msal/application.py
+++ b/msal/application.py
@@ -249,8 +249,11 @@ class ClientApplication(object):
             MSAL's default value is None, which means region behavior remains off.
             If enabled, some of the MSAL traffic would remain inside that region.
 
-            App developer can opt in to regional endpoint,
-            by provide a region name, such as "westus", "eastus2".
+            App developer can opt in to a regional endpoint,
+            by provide its region name, such as "westus", "eastus2".
+            You can find a full list of regions by running
+            ``az account list-locations -o table``, or referencing to
+            `this doc <https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.resourcemanager.fluent.core.region?view=azure-dotnet>`_.
 
             An app running inside Azure VM can use a special keyword
             ``ClientApplication.ATTEMPT_REGION_DISCOVERY`` to auto-detect region.

--- a/msal/application.py
+++ b/msal/application.py
@@ -256,7 +256,7 @@ class ClientApplication(object):
             ``az account list-locations -o table``, or referencing to
             `this doc <https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.resourcemanager.fluent.core.region?view=azure-dotnet>`_.
 
-            An app running inside Azure VM can use a special keyword
+            An app running inside Azure Functions and Azure VM can use a special keyword
             ``ClientApplication.ATTEMPT_REGION_DISCOVERY`` to auto-detect region.
             (Attempting this on a non-VM could hang indefinitely.
             Make sure you configure a short timeout,

--- a/msal/application.py
+++ b/msal/application.py
@@ -109,7 +109,7 @@ class ClientApplication(object):
     GET_ACCOUNTS_ID = "902"
     REMOVE_ACCOUNT_ID = "903"
 
-    ATTEMPT_REGION_DISCOVERY = "TryAutoDetect"
+    ATTEMPT_REGION_DISCOVERY = True  # "TryAutoDetect"
 
     def __init__(
             self, client_id,
@@ -242,7 +242,8 @@ class ClientApplication(object):
                (However MSAL Python does not support managed identity,
                so this one does not apply.)
 
-            3. An app authenticated by Subject Name/Issuer (SNI).
+            3. An app authenticated by
+               `Subject Name/Issuer (SNI) <https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/60>`_.
 
             4. An app which already onboard to the region's allow-list.
 
@@ -258,10 +259,22 @@ class ClientApplication(object):
 
             An app running inside Azure Functions and Azure VM can use a special keyword
             ``ClientApplication.ATTEMPT_REGION_DISCOVERY`` to auto-detect region.
-            (Attempting this on a non-VM could hang indefinitely.
-            Make sure you configure a short timeout,
-            or provide a custom http_client which has a short timeout.
-            That way, the latency would be under your control.)
+
+            .. note::
+
+                Setting ``azure_region`` to non-``None`` for an app running
+                outside of Azure Function/VM could hang indefinitely.
+
+                You should consider opting in/out region behavior on-demand,
+                by loading ``azure_region=None`` or ``azure_region="westus"``
+                or ``azure_region=True`` (which means opt-in and auto-detect)
+                from your per-deployment configuration, and then do
+                ``app = ConfidentialClientApplication(..., azure_region=azure_region)``.
+
+                Alternatively, you can configure a short timeout,
+                or provide a custom http_client which has a short timeout.
+                That way, the latency would be under your control,
+                but still less performant than opting out of region feature.
         """
         self.client_id = client_id
         self.client_credential = client_credential

--- a/msal/region.py
+++ b/msal/region.py
@@ -29,7 +29,12 @@ def _detect_region_of_azure_vm(http_client):
         )
     logger.info(
         "Connecting to IMDS {}. "
-        "You may want to use a shorter timeout on your http_client".format(url))
+        "It may take a while if you are running outside of Azure. "
+        "You should consider opting in/out region behavior on-demand, "
+        'by loading a boolean flag "is_deployed_in_azure" '
+        'from your per-deployment config and then do '
+        '"app = ConfidentialClientApplication(..., '
+        'azure_region=is_deployed_in_azure)"'.format(url))
     try:
         # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#instance-metadata
         resp = http_client.get(url, headers={"Metadata": "true"})

--- a/msal/region.py
+++ b/msal/region.py
@@ -5,8 +5,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _detect_region(http_client):
-    return _detect_region_of_azure_function() or _detect_region_of_azure_vm(http_client)
+def _detect_region(http_client=None):
+    region = _detect_region_of_azure_function()  # It is cheap, so we do it always
+    if http_client and not region:
+        return _detect_region_of_azure_vm(http_client)  # It could hang for minutes
+    return region
 
 
 def _detect_region_of_azure_function():
@@ -15,11 +18,15 @@ def _detect_region_of_azure_function():
 
 def _detect_region_of_azure_vm(http_client):
     url = "http://169.254.169.254/metadata/instance?api-version=2021-01-01"
+    logger.info(
+        "Connecting to IMDS {}. "
+        "You may want to use a shorter timeout on your http_client".format(url))
     try:
         # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#instance-metadata
         resp = http_client.get(url, headers={"Metadata": "true"})
     except:
-        logger.info("IMDS {} unavailable. Perhaps not running in Azure VM?".format(url))
+        logger.info(
+            "IMDS {} unavailable. Perhaps not running in Azure VM?".format(url))
         return None
     else:
         return json.loads(resp.text)["compute"]["location"]

--- a/msal/region.py
+++ b/msal/region.py
@@ -1,5 +1,4 @@
 import os
-import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -17,7 +16,17 @@ def _detect_region_of_azure_function():
 
 
 def _detect_region_of_azure_vm(http_client):
-    url = "http://169.254.169.254/metadata/instance?api-version=2021-01-01"
+    url = (
+        "http://169.254.169.254/metadata/instance"
+
+        # Utilize the "route parameters" feature to obtain region as a string
+        # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#route-parameters
+        "/compute/location?format=text"
+
+        # Location info is available since API version 2017-04-02
+        # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#response-1
+        "&api-version=2021-01-01"
+        )
     logger.info(
         "Connecting to IMDS {}. "
         "You may want to use a shorter timeout on your http_client".format(url))
@@ -29,5 +38,5 @@ def _detect_region_of_azure_vm(http_client):
             "IMDS {} unavailable. Perhaps not running in Azure VM?".format(url))
         return None
     else:
-        return json.loads(resp.text)["compute"]["location"]
+        return resp.text.strip()
 

--- a/msal/region.py
+++ b/msal/region.py
@@ -1,0 +1,26 @@
+import os
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_region(http_client):
+    return _detect_region_of_azure_function() or _detect_region_of_azure_vm(http_client)
+
+
+def _detect_region_of_azure_function():
+    return os.environ.get("REGION_NAME")
+
+
+def _detect_region_of_azure_vm(http_client):
+    url = "http://169.254.169.254/metadata/instance?api-version=2021-01-01"
+    try:
+        # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#instance-metadata
+        resp = http_client.get(url, headers={"Metadata": "true"})
+    except:
+        logger.info("IMDS {} unavailable. Perhaps not running in Azure VM?".format(url))
+        return None
+    else:
+        return json.loads(resp.text)["compute"]["location"]
+

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
             # We will go with "<4" for now, which is also what our another dependency,
             # pyjwt, currently use.
 
+        "mock;python_version<'3.3'",
     ]
 )
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -750,15 +750,13 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
     def test_acquire_token_for_client_should_hit_regional_endpoint(self):
         """This is the only grant supported by regional endpoint, for now"""
         self.app = get_lab_app(  # Regional endpoint only supports confidential client
-            ## Would fail the OIDC Discovery
-            #authority="https://westus2.login.microsoftonline.com/"
-            #    "72f988bf-86f1-41af-91ab-2d7cd011db47",  # Microsoft tenant ID
 
+            ## FWIW, the MSAL<1.12 versions could use this to achieve similar result
             #authority="https://westus.login.microsoft.com/microsoft.onmicrosoft.com",
             #validate_authority=False,
-
             authority="https://login.microsoftonline.com/microsoft.onmicrosoft.com",
             azure_region=self.region,  # Explicitly use this region, regardless of detection
+
             timeout=2,  # Short timeout makes this test case responsive on non-VM
             )
         scopes = ["https://graph.microsoft.com/.default"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -27,7 +27,7 @@ def _get_app_and_auth_code(
         app = msal.ConfidentialClientApplication(
             client_id,
             client_credential=client_secret,
-            authority=authority, http_client=MinimalHttpClient(timeout=2))
+            authority=authority, http_client=MinimalHttpClient())
     else:
         app = msal.PublicClientApplication(
             client_id, authority=authority, http_client=MinimalHttpClient())
@@ -292,7 +292,7 @@ class FileBasedTestCase(E2eTestCase):
             self.config["client_id"],
             client_credential=self.config.get("client_secret"),
             authority=self.config.get("authority"),
-            http_client=MinimalHttpClient(timeout=2))
+            http_client=MinimalHttpClient())
         scope = self.config.get("scope", [])
         result = self.app.acquire_token_for_client(scope)
         self.assertIn('access_token', result)
@@ -307,7 +307,7 @@ class FileBasedTestCase(E2eTestCase):
         self.app = msal.ConfidentialClientApplication(
             self.config['client_id'],
             {"private_key": private_key, "thumbprint": client_cert["thumbprint"]},
-            http_client=MinimalHttpClient(timeout=2))
+            http_client=MinimalHttpClient())
         scope = self.config.get("scope", [])
         result = self.app.acquire_token_for_client(scope)
         self.assertIn('access_token', result)
@@ -330,7 +330,7 @@ class FileBasedTestCase(E2eTestCase):
                 "thumbprint": self.config["thumbprint"],
                 "public_certificate": public_certificate,
                 },
-            http_client=MinimalHttpClient(timeout=2))
+            http_client=MinimalHttpClient())
         scope = self.config.get("scope", [])
         result = self.app.acquire_token_for_client(scope)
         self.assertIn('access_token', result)
@@ -379,7 +379,7 @@ def get_lab_app(
             client_id,
             client_credential=client_secret,
             authority=authority,
-            http_client=MinimalHttpClient(timeout=2),
+            http_client=MinimalHttpClient(),
             **kwargs)
 
 def get_session(lab_app, scopes):  # BTW, this infrastructure tests the confidential client flow
@@ -528,7 +528,7 @@ class LabBasedTestCase(E2eTestCase):
             config_cca["client_id"],
             client_credential=config_cca["client_secret"],
             authority=config_cca["authority"],
-            http_client=MinimalHttpClient(timeout=2),
+            http_client=MinimalHttpClient(),
             # token_cache= ...,  # Default token cache is all-tokens-store-in-memory.
                 # That's fine if OBO app uses short-lived msal instance per session.
                 # Otherwise, the OBO app need to implement a one-cache-per-user setup.
@@ -556,7 +556,7 @@ class LabBasedTestCase(E2eTestCase):
         assert client_id and client_secret and authority and scope
         app = msal.ConfidentialClientApplication(
             client_id, client_credential=client_secret, authority=authority,
-            http_client=MinimalHttpClient(timeout=2))
+            http_client=MinimalHttpClient())
         result = app.acquire_token_for_client(scope)
         self.assertIsNotNone(result.get("access_token"), "Got %s instead" % result)
 
@@ -758,7 +758,7 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
         scopes = ["https://graph.microsoft.com/.default"]
         result = self.app.acquire_token_for_client(
             scopes,
-            params={"AllowEstsRNonMsi": "true"},  # For testing regional endpoint
+            params={"AllowEstsRNonMsi": "true"},  # For testing regional endpoint. It will be removed once MSAL Python 1.12+ has been onboard to ESTS-R
             )
         self.assertIn('access_token', result)
         self.assertCacheWorksForApp(result, scopes)
@@ -855,7 +855,7 @@ class ArlingtonCloudTestCase(LabBasedTestCase):
             usertype="cloud", azureenvironment=self.environment, publicClient="no")
         app = msal.ConfidentialClientApplication(
             config['client_id'], authority=config['authority'],
-            http_client=MinimalHttpClient(timeout=2))
+            http_client=MinimalHttpClient())
         result = app.acquire_token_silent(scopes=config['scope'], account=None)
         self.assertEqual(result, None)
         # Note: An alias in this region is no longer accepting HTTPS traffic.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -758,7 +758,7 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
             #validate_authority=False,
 
             authority="https://login.microsoftonline.com/microsoft.onmicrosoft.com",
-            region=self.region,  # Explicitly use this region, regardless of detection
+            azure_region=self.region,  # Explicitly use this region, regardless of detection
             timeout=2,  # Short timeout makes this test case responsive on non-VM
             )
         scopes = ["https://graph.microsoft.com/.default"]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -353,6 +353,7 @@ def get_lab_app(
         env_client_secret="LAB_APP_CLIENT_SECRET",
         authority="https://login.microsoftonline.com/"
             "72f988bf-86f1-41af-91ab-2d7cd011db47",  # Microsoft tenant ID
+        timeout=None,
         **kwargs):
     """Returns the lab app as an MSAL confidential client.
 
@@ -379,7 +380,7 @@ def get_lab_app(
             client_id,
             client_credential=client_secret,
             authority=authority,
-            http_client=MinimalHttpClient(),
+            http_client=MinimalHttpClient(timeout=timeout),
             **kwargs)
 
 def get_session(lab_app, scopes):  # BTW, this infrastructure tests the confidential client flow
@@ -754,6 +755,7 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
 
             authority="https://login.microsoftonline.com/microsoft.onmicrosoft.com",
             region=self.region,  # Explicitly use this region, regardless of detection
+            timeout=2,  # Short timeout makes this test case responsive on non-VM
             )
         scopes = ["https://graph.microsoft.com/.default"]
         result = self.app.acquire_token_for_client(


### PR DESCRIPTION
This resolves #295.

Feature wise this is completed.

~~TODO: Currently the authority validation is still performed. Would need to decide whether that is desirable. CC: @bgavrilMS~~ Now MSAL will ignore connection error during Authority Validation if app developer opted in to use `azure_region`.