### PR TITLE
A demo on how to use prompt=create

### DIFF
--- a/msal/__init__.py
+++ b/msal/__init__.py
@@ -31,5 +31,6 @@ from .application import (
     ConfidentialClientApplication,
     PublicClientApplication,
     )
+from .oauth2cli.oidc import Prompt
 from .token_cache import TokenCache, SerializableTokenCache
 

--- a/msal/oauth2cli/oidc.py
+++ b/msal/oauth2cli/oidc.py
@@ -83,6 +83,19 @@ def _nonce_hash(nonce):
     return hashlib.sha256(nonce.encode("ascii")).hexdigest()
 
 
+class Prompt(object):
+    """This class defines the constant strings for prompt parameter.
+
+    The values are based on
+    https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+    """
+    NONE = "none"
+    LOGIN = "login"
+    CONSENT = "consent"
+    SELECT_ACCOUNT = "select_account"
+    CREATE = "create"  # Defined in https://openid.net/specs/openid-connect-prompt-create-1_0.html#PromptParameter
+
+
 class Client(oauth2.Client):
     """OpenID Connect is a layer on top of the OAuth2.
 
@@ -217,6 +230,8 @@ class Client(oauth2.Client):
             `OIDC <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_.
         :param string prompt: Defined in
             `OIDC <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_.
+            You can find the valid string values defined in :class:`oidc.Prompt`.
+
         :param int max_age: Defined in
             `OIDC <https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest>`_.
         :param string ui_locales: Defined in
@@ -232,7 +247,7 @@ class Client(oauth2.Client):
         for descriptions on other parameters and return value.
         """
         filtered_params = {k:v for k, v in dict(
-            prompt=prompt,
+            prompt=" ".join(prompt) if isinstance(prompt, (list, tuple)) else prompt,
             display=display,
             max_age=max_age,
             ui_locales=ui_locales,

--- a/sample/interactive_sample.py
+++ b/sample/interactive_sample.py
@@ -63,6 +63,8 @@ if not result:
             # by using the preferred_username claim from returned id_token_claims.
 
         #prompt="select_account",  # Optional. It forces to show account selector page
+        #prompt="create",  # Optional. It brings user to a self-service sign-up flow.
+            # Prerequisite: https://docs.microsoft.com/en-us/azure/active-directory/external-identities/self-service-sign-up-user-flow
         )
 
 if "access_token" in result:

--- a/sample/interactive_sample.py
+++ b/sample/interactive_sample.py
@@ -62,8 +62,8 @@ if not result:
             # after already extracting the username from an earlier sign-in
             # by using the preferred_username claim from returned id_token_claims.
 
-        #prompt="select_account",  # Optional. It forces to show account selector page
-        #prompt="create",  # Optional. It brings user to a self-service sign-up flow.
+        #prompt=msal.Prompt.SELECT_ACCOUNT,  # Or simply "select_account". Optional. It forces to show account selector page
+        #prompt=msal.Prompt.CREATE,  # Or simply "create". Optional. It brings user to a self-service sign-up flow.
             # Prerequisite: https://docs.microsoft.com/en-us/azure/active-directory/external-identities/self-service-sign-up-user-flow
         )
 


### PR DESCRIPTION
By design, MSAL Python's `acquire_token_interactive(..., prompt=...)` always accepts arbitrary string, so this feature has already been shipped last year.

This PR adds a line in the dev sample to show how to use it.

This PR is now the last action item of #356 , so, it will resolve #356.