### PR TITLE
Fix NameError in ClientApplication exception handler

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -299,7 +299,7 @@ class ClientApplication(object):
         except ValueError:  # Those are explicit authority validation errors
             raise
         except Exception:  # The rest are typically connection errors
-            if validate_authority and region:
+            if validate_authority and azure_region:
                 # Since caller opts in to use region, here we tolerate connection
                 # errors happened during authority validation at non-region endpoint
                 self.authority = Authority(


### PR DESCRIPTION
To reproduce the error:
```py
from msal import PublicClientApplication

class Client:
    def get(*args, **kwargs):
        raise Exception('oops')

PublicClientApplication('...', http_client=Client())
```
```
Traceback (most recent call last):
  File "repro.py", line 8, in <module>
    PublicClientApplication("...", http_client=Client())
  File "...lib\site-packages\msal\application.py", line 1296, in __init__
    super(PublicClientApplication, self).__init__(
  File "...lib\site-packages\msal\application.py", line 302, in __init__
    if validate_authority and region:
NameError: name 'region' is not defined
```

I assume the keyword argument `azure_region` is intended.