### PR TITLE
Changing region endpoint, and remove usage of REGION_NAME env var

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -371,7 +371,7 @@ class ClientApplication(object):
             self._region_configured if is_region_specified else self._region_detected)
         if region_to_use:
             logger.info('Region to be used: {}'.format(repr(region_to_use)))
-            regional_host = ("{}.login.microsoft.com".format(region_to_use)
+            regional_host = ("{}.r.login.microsoftonline.com".format(region_to_use)
                 if central_authority.instance in (
                     # The list came from https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/358/files#r629400328
                     "login.microsoftonline.com",

--- a/msal/region.py
+++ b/msal/region.py
@@ -5,14 +5,9 @@ logger = logging.getLogger(__name__)
 
 
 def _detect_region(http_client=None):
-    region = _detect_region_of_azure_function()  # It is cheap, so we do it always
-    if http_client and not region:
+    if http_client:
         return _detect_region_of_azure_vm(http_client)  # It could hang for minutes
-    return region
-
-
-def _detect_region_of_azure_function():
-    return os.environ.get("REGION_NAME")
+    return None
 
 
 def _detect_region_of_azure_vm(http_client):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -798,7 +798,7 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
                 status_code=400, text='{"error": "mock"}')) as mocked_method:
             self.app.acquire_token_for_client(scopes)
             mocked_method.assert_called_with(
-                'https://westus.login.microsoft.com/{}/oauth2/v2.0/token'.format(
+                'https://westus.r.login.microsoftonline.com/{}/oauth2/v2.0/token'.format(
                     self.app.authority.tenant),
                 params=ANY, data=ANY, headers=ANY)
         result = self.app.acquire_token_for_client(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -137,10 +137,15 @@ class E2eTestCase(unittest.TestCase):
     def _test_username_password(self,
             authority=None, client_id=None, username=None, password=None, scope=None,
             client_secret=None,  # Since MSAL 1.11, confidential client has ROPC too
+            azure_region=None,
+            http_client=None,
             **ignored):
         assert authority and client_id and username and password and scope
         self.app = msal.ClientApplication(
-            client_id, authority=authority, http_client=MinimalHttpClient(),
+            client_id, authority=authority,
+            http_client=http_client or MinimalHttpClient(),
+            azure_region=azure_region,  # Regional endpoint does not support ROPC.
+                # Here we just use it to test a regional app won't break ROPC.
             client_credential=client_secret)
         result = self.app.acquire_token_by_username_password(
             username, password, scopes=scope)
@@ -541,11 +546,16 @@ class LabBasedTestCase(E2eTestCase):
                 error_description=result.get("error_description")))
         self.assertCacheWorksForUser(result, scope, username=None)
 
-    def _test_acquire_token_obo(self, config_pca, config_cca):
+    def _test_acquire_token_obo(self, config_pca, config_cca,
+            azure_region=None,  # Regional endpoint does not really support OBO.
+                # Here we just test regional apps won't adversely break OBO
+            http_client=None,
+            ):
         # 1. An app obtains a token representing a user, for our mid-tier service
         pca = msal.PublicClientApplication(
             config_pca["client_id"], authority=config_pca["authority"],
-            http_client=MinimalHttpClient())
+            azure_region=azure_region,
+            http_client=http_client or MinimalHttpClient())
         pca_result = pca.acquire_token_by_username_password(
             config_pca["username"],
             config_pca["password"],
@@ -560,7 +570,8 @@ class LabBasedTestCase(E2eTestCase):
             config_cca["client_id"],
             client_credential=config_cca["client_secret"],
             authority=config_cca["authority"],
-            http_client=MinimalHttpClient(),
+            azure_region=azure_region,
+            http_client=http_client or MinimalHttpClient(),
             # token_cache= ...,  # Default token cache is all-tokens-store-in-memory.
                 # That's fine if OBO app uses short-lived msal instance per session.
                 # Otherwise, the OBO app need to implement a one-cache-per-user setup.
@@ -778,6 +789,7 @@ class WorldWideTestCase(LabBasedTestCase):
 
 class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
     region = "westus"
+    timeout = 2  # Short timeout makes this test case responsive on non-VM
 
     def test_acquire_token_for_client_should_hit_regional_endpoint(self):
         """This is the only grant supported by regional endpoint, for now"""
@@ -808,15 +820,6 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
         self.assertIn('access_token', result)
         self.assertCacheWorksForApp(result, scopes)
 
-
-class RegionalEndpointViaEnvVarTestCase(WorldWideRegionalEndpointTestCase):
-
-    def setUp(self):
-        os.environ["REGION_NAME"] = "eastus"
-
-    def tearDown(self):
-        del os.environ["REGION_NAME"]
-
     @unittest.skipUnless(
         os.getenv("LAB_OBO_CLIENT_SECRET"),
         "Need LAB_OBO_CLIENT_SECRET from https://aka.ms/GetLabSecret?Secret=TodoListServiceV2-OBO")
@@ -842,7 +845,11 @@ class RegionalEndpointViaEnvVarTestCase(WorldWideRegionalEndpointTestCase):
         config_pca["password"] = self.get_lab_user_secret(config_pca["lab_name"])
         config_pca["scope"] = ["api://%s/read" % config_cca["client_id"]]
 
-        self._test_acquire_token_obo(config_pca, config_cca)
+        self._test_acquire_token_obo(
+            config_pca, config_cca,
+            azure_region=self.region,
+            http_client=MinimalHttpClient(timeout=self.timeout),
+            )
 
     @unittest.skipUnless(
         os.getenv("LAB_OBO_CLIENT_SECRET"),
@@ -859,7 +866,10 @@ class RegionalEndpointViaEnvVarTestCase(WorldWideRegionalEndpointTestCase):
         config["client_id"] = os.getenv("LAB_OBO_CONFIDENTIAL_CLIENT_ID")
         config["scope"] = ["https://graph.microsoft.com/.default"]
         config["client_secret"] = os.getenv("LAB_OBO_CLIENT_SECRET")
-        self._test_username_password(**config)
+        self._test_username_password(
+            azure_region=self.region,
+            http_client=MinimalHttpClient(timeout=self.timeout),
+            **config)
 
 
 class ArlingtonCloudTestCase(LabBasedTestCase):


### PR DESCRIPTION
The previous regional endpoint behavior implemented in #358 would receive some changes defined in [this internal memo](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/3768). In particular, the removal of `REGION_NAME` usage would also close #382.