### PR TITLE
Allow interactive flow to be aborted by CTRL+C even when running on Windows

### DIFF
--- a/msal/oauth2cli/oauth2.py
+++ b/msal/oauth2cli/oauth2.py
@@ -199,7 +199,7 @@ class BaseClient(object):
             _data["client_assertion"] = encoder(
                 self.client_assertion()  # Do lazy on-the-fly computation
                 if callable(self.client_assertion) else self.client_assertion
-                )   # The type is bytes, which is preferrable. See also:
+                )   # The type is bytes, which is preferable. See also:
                     # https://github.com/psf/requests/issues/4503#issuecomment-455001070
 
         _data.update(self.default_body)  # It may contain authen parameters


### PR DESCRIPTION
This PR fix #393 which only happens on Windows.