### PR TITLE
Fix: Ctrl+C results in handle_request failure

### DIFF
--- a/msal/oauth2cli/authcode.py
+++ b/msal/oauth2cli/authcode.py
@@ -90,6 +90,8 @@ class _AuthCodeHandler(BaseHTTPRequestHandler):
                 template.safe_substitute(**self.server.auth_response))
             # NOTE: Don't do self.server.shutdown() here. It'll halt the server.
         else:
+            # No query string. Not a valid request. Fill auth_response with anything as long as it is not empty.
+            self.server.auth_response = {"invalid_request": None}
             self._send_full_response(self.server.welcome_page)
 
     def _send_full_response(self, body, is_ok=True):
@@ -267,6 +269,11 @@ class AuthCodeReceiver(object):
                     logger.debug("State mismatch. Ignoring this noise.")
                 else:
                     break
+            else:
+                # self._server.auth_response is empty, meaning the server is shutdown
+                # before any request is handled.
+                logger.debug("Server is shutdown before any request is handled.")
+                break
         result.update(self._server.auth_response)  # Return via writable result param
 
     def close(self):


### PR DESCRIPTION
Refine https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/404

## Symptom

`_AuthCodeReceiver` is used as a context manager:

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/f97cb7c69d1f5c2eed6c85e28dd828b2434263b4/msal/oauth2cli/oauth2.py#L636

When <kbd>Ctrl</kbd>+<kbd>C</kbd> is pressed, Python calls 

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/f97cb7c69d1f5c2eed6c85e28dd828b2434263b4/msal/oauth2cli/authcode.py#L279-L280

then

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/f97cb7c69d1f5c2eed6c85e28dd828b2434263b4/msal/oauth2cli/authcode.py#L272-L274

This shuts down the server and causes 

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/f97cb7c69d1f5c2eed6c85e28dd828b2434263b4/msal/oauth2cli/authcode.py#L264

to return.

Because of the outer loop

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/f97cb7c69d1f5c2eed6c85e28dd828b2434263b4/msal/oauth2cli/authcode.py#L261
,

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/f97cb7c69d1f5c2eed6c85e28dd828b2434263b4/msal/oauth2cli/authcode.py#L264

is called again. However, as the server has been shut down, it fails with

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\threading.py", line 973, in _bootstrap_inner
    self.run()
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\threading.py", line 910, in run
    self._target(*self._args, **self._kwargs)
  File "d:\cli-msal\microsoft-authentication-library-for-python\msal\oauth2cli\authcode.py", line 264, in _get_auth_response
    self._server.handle_request()
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\socketserver.py", line 291, in handle_request
    selector.register(self, selectors.EVENT_READ)
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\selectors.py", line 300, in register
    key = super().register(fileobj, events, data)
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\selectors.py", line 239, in register
    key = SelectorKey(fileobj, self._fileobj_lookup(fileobj), events, data)
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\selectors.py", line 226, in _fileobj_lookup
    return _fileobj_to_fd(fileobj)
  File "C:\Users\user1\AppData\Local\Programs\Python\Python39\lib\selectors.py", line 42, in _fileobj_to_fd
    raise ValueError("Invalid file descriptor: {}".format(fd))
ValueError: Invalid file descriptor: -1
```

## Change

If a request is handled by `msal.oauth2cli.authcode._AuthCodeHandler.do_GET`, `self.server.auth_response` will always be set. Later on, if `self._server.handle_request()` returns leaving an empty `self.server.auth_response`, that means the server is shutdown before any request is handled, so we break the loop.



