### PR TITLE
Broker integration

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -444,9 +444,22 @@ class ClientApplication(object):
             New in version 1.19.0.
 
         :param boolean allow_broker:
-            Brokers provide Single-Sign-On, device identification,
-            and application identification verification.
-            This flag defaults to None, which means MSAL will not utilize broker.
+            A broker is a component installed on your device.
+            Broker implicitly gives your device an identity. By using a broker,
+            your device becomes a factor that can satisfy MFA (Multi-factor authentication).
+            This factor would become mandatory
+            if a tenant's admin enables a corresponding Conditional Access (CA) policy.
+            The broker's presence allows Microsoft identity platform
+            to have higher confidence that the tokens are being issued to your device,
+            and that is more secure.
+
+            An additional benefit of broker is,
+            it runs as a long-lived process with your device's OS,
+            and maintains its own cache,
+            so that your broker-enabled apps (even a CLI)
+            could automatically SSO from a previously established signed-in session.
+
+            This parameter defaults to None, which means MSAL will not utilize a broker.
             If this parameter is set to True,
             MSAL will use the broker whenever possible,
             and automatically fall back to non-broker behavior.

--- a/msal/application.py
+++ b/msal/application.py
@@ -1857,6 +1857,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
         if login_hint and prompt != "select_account":  # OIDC prompts when the user did not sign in
             accounts = self.get_accounts(username=login_hint)
             if len(accounts) == 1:  # Unambiguously proceed with this account
+                logger.debug("Calling broker._acquire_token_silently()")
                 response = _acquire_token_silently(  # When it works, it bypasses prompt
                     authority,
                     self.client_id,
@@ -1868,6 +1869,7 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
                     return self._process_broker_response(response, scopes, data)
         # login_hint undecisive or not exists
         if prompt == "none" or not prompt:  # Must/Can attempt _signin_silently()
+            logger.debug("Calling broker._signin_silently()")
             response = _signin_silently(  # Unlike OIDC, it doesn't honor login_hint
                 authority, self.client_id, scopes,
                 validateAuthority=validate_authority,
@@ -1903,7 +1905,8 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
                     pass  # It will fall back to the _signin_interactively()
                 else:
                     return self._process_broker_response(response, scopes, data)
-        # Falls back to _signin_interactively()
+
+        logger.debug("Falls back to broker._signin_interactively()")
         on_before_launching_ui(ui="broker")
         response = _signin_interactively(
             authority, self.client_id, scopes,

--- a/msal/application.py
+++ b/msal/application.py
@@ -17,7 +17,7 @@ from .authority import Authority
 from .mex import send_request as mex_send_request
 from .wstrust_request import send_request as wst_send_request
 from .wstrust_response import *
-from .token_cache import TokenCache
+from .token_cache import TokenCache, _get_username
 import msal.telemetry
 from .region import _detect_region
 from .throttled_http_client import ThrottledHttpClient
@@ -25,7 +25,7 @@ from .cloudshell import _is_running_in_cloud_shell
 
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.18.0"  # When releasing, also check and bump our dependencies's versions if needed
+__version__ = "1.20.0b1"  # When releasing, also check and bump our dependencies's versions if needed
 
 logger = logging.getLogger(__name__)
 _AUTHORITY_TYPE_CLOUDSHELL = "CLOUDSHELL"
@@ -67,8 +67,12 @@ def _str2bytes(raw):
 
 def _clean_up(result):
     if isinstance(result, dict):
-        result.pop("refresh_in", None)  # MSAL handled refresh_in, customers need not
-    return result
+        return {
+            k: result[k] for k in result
+            if k != "refresh_in"  # MSAL handled refresh_in, customers need not
+            and not k.startswith('_')  # Skim internal properties
+            }
+    return result  # It could be None
 
 
 def _preferred_browser():
@@ -174,6 +178,7 @@ class ClientApplication(object):
                 # when we would eventually want to add this feature to PCA in future.
             exclude_scopes=None,
             http_cache=None,
+            allow_broker=None,
             ):
         """Create an instance of application.
 
@@ -409,6 +414,34 @@ class ClientApplication(object):
             Personally Identifiable Information (PII). Encryption is unnecessary.
 
             New in version 1.16.0.
+
+        :param boolean allow_broker:
+            Brokers provide Single-Sign-On, device identification,
+            and application identification verification.
+            If this parameter is set to True,
+            MSAL will use the broker and return either a token or an error,
+            when your scenario is supported by a broker,
+            otherwise it will automatically fall back to non-broker behavior.
+            This also means you could set this flag as True universally,
+            as long as your app meets the following prerequisite:
+
+            * Installed optional dependency, e.g. ``pip install msal[broker]>=1.20,<2``.
+              (Note that broker is currently only available on Windows 10+)
+
+            * Register a new redirect_uri for your desktop app as:
+              ``ms-appx-web://Microsoft.AAD.BrokerPlugin/your_client_id``
+
+            * Tested your app in following scenarios:
+
+              * Windows 10+
+
+              * PublicClientApplication's following methods::
+                acquire_token_interactive(), acquire_token_by_username_password(),
+                acquire_token_silent() (or acquire_token_silent_with_error()).
+
+              * AAD and MSA accounts (i.e. Non-ADFS, non-B2C)
+
+            New in version 1.20.0.
         """
         self.client_id = client_id
         self.client_credential = client_credential
@@ -467,6 +500,15 @@ class ClientApplication(object):
                     self.http_client, validate_authority=False)
             else:
                 raise
+        is_confidential_app = bool(
+            isinstance(self, ConfidentialClientApplication) or self.client_credential)
+        if is_confidential_app and allow_broker:
+            raise ValueError("allow_broker=True is only supported in PublicClientApplication")
+        self._enable_broker = bool(
+            allow_broker and not is_confidential_app
+            and sys.platform == "win32"
+            and not self.authority.is_adfs and not self.authority._is_b2c)
+        logger.debug("Broker enabled? %s", self._enable_broker)
 
         self.token_cache = token_cache or TokenCache()
         self._region_configured = azure_region
@@ -1028,6 +1070,15 @@ class ClientApplication(object):
     def remove_account(self, account):
         """Sign me out and forget me from token cache"""
         self._forget_me(account)
+        if self._enable_broker:
+            try:
+                from .broker import _signout_silently
+            except RuntimeError:  # TODO: TBD
+                logger.debug("Broker is unavailable on this platform. Fallback to non-broker.")
+            else:
+                error = _signout_silently(self.client_id, account["local_account_id"])
+                if error:
+                    logger.debug("_signout_silently() returns error: %s", error)
 
     def _sign_out(self, home_account):
         # Remove all relevant RTs and ATs from token cache
@@ -1255,9 +1306,28 @@ class ClientApplication(object):
             refresh_reason = msal.telemetry.FORCE_REFRESH  # TODO: It could also mean claims_challenge
         assert refresh_reason, "It should have been established at this point"
         try:
+            data = kwargs.get("data", {})
             if account and account.get("authority_type") == _AUTHORITY_TYPE_CLOUDSHELL:
-                return self._acquire_token_by_cloud_shell(
-                    scopes, data=kwargs.get("data"))
+                return self._acquire_token_by_cloud_shell(scopes, data=data)
+
+            if self._enable_broker and account is not None and data.get("token_type") != "ssh-cert":
+                try:
+                    from .broker import _acquire_token_silently
+                except RuntimeError:  # TODO: TBD
+                    logger.debug("Broker is unavailable on this platform. Fallback to non-broker.")
+                else:
+                    response = _acquire_token_silently(
+                        "https://{}/{}".format(self.authority.instance, self.authority.tenant),
+                        self.client_id,
+                        account["local_account_id"],
+                        scopes,
+                        claims=_merge_claims_challenge_and_capabilities(
+                            self._client_capabilities, claims_challenge),
+                        correlation_id=correlation_id,
+                        **data)
+                    if response:  # The broker provided a decisive outcome, so we use it
+                        return self._process_broker_response(response, scopes, data)
+
             result = _clean_up(self._acquire_token_silent_by_finding_rt_belongs_to_me_or_my_family(
                 authority, self._decorate_scope(scopes), account,
                 refresh_reason=refresh_reason, claims_challenge=claims_challenge,
@@ -1270,6 +1340,18 @@ class ClientApplication(object):
             if not access_token_from_cache:  # It means there is no fall back option
                 raise  # We choose to bubble up the exception
         return access_token_from_cache
+
+    def _process_broker_response(self, response, scopes, data):
+        if "error" not in response:
+            self.token_cache.add(dict(
+                client_id=self.client_id,
+                scope=response["scope"].split() if "scope" in response else scopes,
+                token_endpoint=self.authority.token_endpoint,
+                response=response.copy(),
+                data=data,
+                _account_id=response["_account_id"],
+                ))
+        return _clean_up(response)
 
     def _acquire_token_silent_by_finding_rt_belongs_to_me_or_my_family(
             self, authority, scopes, account, **kwargs):
@@ -1447,14 +1529,33 @@ class ClientApplication(object):
             - A successful response would contain "access_token" key,
             - an error response would contain "error" and usually "error_description".
         """
+        claims = _merge_claims_challenge_and_capabilities(
+                self._client_capabilities, claims_challenge)
+        if self._enable_broker:
+            try:
+                from .broker import _signin_silently
+            except RuntimeError:  # TODO: TBD
+                logger.debug("Broker is unavailable on this platform. Fallback to non-broker.")
+            else:
+                response = _signin_silently(
+                    "https://{}/{}".format(self.authority.instance, self.authority.tenant),
+                    self.client_id,
+                    scopes,  # Decorated scopes won't work due to offline_access
+                    MSALRuntime_Username=username,
+                    MSALRuntime_Password=password,
+                    validateAuthority="no"
+                        if self.authority._validate_authority is False
+                        or self.authority.is_adfs or self.authority._is_b2c
+                        else None,
+                    claims=claims,
+                    )
+                return self._process_broker_response(response, scopes, kwargs.get("data", {}))
+
         scopes = self._decorate_scope(scopes)
         telemetry_context = self._build_telemetry_context(
             self.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD_ID)
         headers = telemetry_context.generate_headers()
-        data = dict(
-            kwargs.pop("data", {}),
-            claims=_merge_claims_challenge_and_capabilities(
-                self._client_capabilities, claims_challenge))
+        data = dict(kwargs.pop("data", {}), claims=claims)
         if not self.authority.is_adfs:
             user_realm_result = self.authority.user_realm_discovery(
                 username, correlation_id=headers[msal.telemetry.CLIENT_REQUEST_ID])
@@ -1520,6 +1621,7 @@ class ClientApplication(object):
 class PublicClientApplication(ClientApplication):  # browser app or mobile app
 
     DEVICE_FLOW_CORRELATION_ID = "_correlation_id"
+    CONSOLE_WINDOW_HANDLE = object()
 
     def __init__(self, client_id, client_credential=None, **kwargs):
         if client_credential is not None:
@@ -1538,11 +1640,16 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
             port=None,
             extra_scopes_to_consent=None,
             max_age=None,
+            parent_window_handle=None,
+            on_before_launching_ui=None,
             **kwargs):
         """Acquire token interactively i.e. via a local browser.
 
         Prerequisite: In Azure Portal, configure the Redirect URI of your
         "Mobile and Desktop application" as ``http://localhost``.
+        If you opts in to use broker during ``PublicClientApplication`` creation,
+        your app also need this Redirect URI:
+        ``ms-appx-web://Microsoft.AAD.BrokerPlugin/YOUR_CLIENT_ID``
 
         :param list scopes:
             It is a list of case-sensitive strings.
@@ -1594,17 +1701,79 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
 
             New in version 1.15.
 
+        :param int parent_window_handle:
+            OPTIONAL. If your app is a GUI app running on modern Windows system,
+            and your app opts in to use broker,
+            you are recommended to also provide its window handle,
+            so that the sign in UI window will properly pop up on top of your window.
+
+            New in version 1.20.0.
+
+        :param function on_before_launching_ui:
+            A callback with the form of
+            ``lambda ui="xyz", **kwargs: print("A {} will be launched".format(ui))``,
+            where ``ui`` will be either "browser" or "broker".
+            You can use it to inform your end user to expect a pop-up window.
+
+            New in version 1.20.0.
+
         :return:
             - A dict containing no "error" key,
               and typically contains an "access_token" key.
             - A dict containing an "error" key, when token refresh failed.
         """
-        self._validate_ssh_cert_input_data(kwargs.get("data", {}))
+        data = kwargs.pop("data", {})
+        self._validate_ssh_cert_input_data(data)
+        if not on_before_launching_ui:
+            on_before_launching_ui = lambda **kwargs: None
         if _is_running_in_cloud_shell() and prompt == "none":
-            return self._acquire_token_by_cloud_shell(
-                scopes, data=kwargs.pop("data", {}))
+            # Note: _acquire_token_by_cloud_shell() is always silent,
+            #       so we would not fire on_before_launching_ui()
+            return self._acquire_token_by_cloud_shell(scopes, data=data)
         claims = _merge_claims_challenge_and_capabilities(
             self._client_capabilities, claims_challenge)
+        if self._enable_broker and data.get("token_type") != "ssh-cert":
+            if parent_window_handle is None:
+                raise ValueError(
+                    "parent_window_handle is required when you opted into using broker. "
+                    "You need to provide the window handle of your GUI application, "
+                    "or use msal.PublicClientApplication.CONSOLE_WINDOW_HANDLE "
+                    "when and only when your application is a console app.")
+            if extra_scopes_to_consent:
+                logger.warning(
+                    "Ignoring parameter extra_scopes_to_consent, "
+                    "which is not supported by broker")
+            enable_msa_passthrough = kwargs.pop(
+                "enable_msa_passthrough",  # Keep it as a hidden param, for now.
+                    # OPTIONAL. MSA-Passthrough is a legacy configuration,
+                    # needed by a small amount of Microsoft first-party apps,
+                    # which would login MSA accounts via ".../organizations" authority.
+                    # If you app belongs to this category, AND you are enabling broker,
+                    # you would want to enable this flag. Default value is equivalent to False.
+                self.client_id in [
+                    # Experimental: Automatically enable MSA-PT mode for known MSA-PT apps
+                    # More background of MSA-PT is available from this internal docs:
+                    # https://microsoft.sharepoint.com/:w:/t/Identity-DevEx/EatIUauX3c9Ctw1l7AQ6iM8B5CeBZxc58eoQCE0IuZ0VFw?e=tgc3jP&CID=39c853be-76ea-79d7-ee73-f1b2706ede05
+                    "04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Azure CLI
+                    "04f0c124-f2bc-4f59-8241-bf6df9866bbd",  # Visual Studio
+                    ] and data.get("token_type") != "ssh-cert"  # Work around a known issue as of PyMsalRuntime 0.8
+                )
+            try:
+                return self._acquire_token_interactive_via_broker(
+                    scopes,
+                    parent_window_handle,
+                    enable_msa_passthrough,
+                    claims,
+                    data,
+                    on_before_launching_ui,
+                    prompt=prompt,
+                    login_hint=login_hint,
+                    max_age=max_age,
+                    )
+            except RuntimeError:  # TODO: TBD
+                logger.debug("Broker is unavailable on this platform. Fallback to non-broker.")
+
+        on_before_launching_ui(ui="browser")
         telemetry_context = self._build_telemetry_context(
             self.ACQUIRE_TOKEN_INTERACTIVE)
         response = _clean_up(self.client.obtain_token_by_browser(
@@ -1621,12 +1790,98 @@ class PublicClientApplication(ClientApplication):  # browser app or mobile app
                 "claims": claims,
                 "domain_hint": domain_hint,
                 },
-            data=dict(kwargs.pop("data", {}), claims=claims),
+            data=dict(data, claims=claims),
             headers=telemetry_context.generate_headers(),
             browser_name=_preferred_browser(),
             **kwargs))
         telemetry_context.update_telemetry(response)
         return response
+
+    def _acquire_token_interactive_via_broker(
+            self,
+            scopes,  # type: list[str]
+            parent_window_handle,  # type: int
+            enable_msa_passthrough,  # type: boolean
+            claims,  # type: str
+            data,  # type: dict
+            on_before_launching_ui,  # type: callable
+            prompt=None,
+            login_hint=None,  # type: Optional[str]
+            max_age=None,
+            **kwargs):
+        from .broker import _signin_interactively, _signin_silently, _acquire_token_silently
+        if "welcome_template" in kwargs:
+            logger.debug(kwargs["welcome_template"])  # Experimental
+        authority = "https://{}/{}".format(
+            self.authority.instance, self.authority.tenant)
+        validate_authority = (
+            "no" if self.authority._validate_authority is False
+                or self.authority.is_adfs or self.authority._is_b2c
+            else None)
+        # Calls different broker methods to mimic the OIDC behaviors
+        if login_hint and prompt != "select_account":  # OIDC prompts when the user did not sign in
+            accounts = self.get_accounts(username=login_hint)
+            if len(accounts) == 1:  # Unambiguously proceed with this account
+                response = _acquire_token_silently(  # When it works, it bypasses prompt
+                    authority,
+                    self.client_id,
+                    accounts[0]["local_account_id"],
+                    scopes,
+                    claims=claims,
+                    **data)
+                if response and "error" not in response:
+                    return self._process_broker_response(response, scopes, data)
+        # login_hint undecisive or not exists
+        if prompt == "none" or not prompt:  # Must/Can attempt _signin_silently()
+            response = _signin_silently(  # Unlike OIDC, it doesn't honor login_hint
+                authority, self.client_id, scopes,
+                validateAuthority=validate_authority,
+                claims=claims,
+                max_age=max_age,
+                enable_msa_pt=enable_msa_passthrough,
+                **data)
+            is_wrong_account = bool(
+                # _signin_silently() only gets tokens for default account,
+                # but this seems to have been fixed in PyMsalRuntime 0.11.2
+                "access_token" in response and login_hint
+                and response.get("id_token_claims", {}) != login_hint)
+            wrong_account_error_message = (
+                'prompt="none" will not work for login_hint="non-default-user"')
+            if is_wrong_account:
+                logger.debug(wrong_account_error_message)
+            if prompt == "none":
+                return self._process_broker_response(  # It is either token or error
+                        response, scopes, data
+                    ) if not is_wrong_account else {
+                        "error": "broker_error",
+                        "error_description": wrong_account_error_message,
+                    }
+            else:
+                assert bool(prompt) is False
+                from pymsalruntime import Response_Status
+                recoverable_errors = frozenset([
+                    Response_Status.Status_AccountUnusable,
+                    Response_Status.Status_InteractionRequired,
+                    ])
+                if is_wrong_account or "error" in response and response.get(
+                        "_broker_status") in recoverable_errors:
+                    pass  # It will fall back to the _signin_interactively()
+                else:
+                    return self._process_broker_response(response, scopes, data)
+        # Falls back to _signin_interactively()
+        on_before_launching_ui(ui="broker")
+        response = _signin_interactively(
+            authority, self.client_id, scopes,
+            None if parent_window_handle is self.CONSOLE_WINDOW_HANDLE
+                else parent_window_handle,
+            validateAuthority=validate_authority,
+            login_hint=login_hint,
+            prompt=prompt,
+            claims=claims,
+            max_age=max_age,
+            enable_msa_pt=enable_msa_passthrough,
+            **data)
+        return self._process_broker_response(response, scopes, data)
 
     def initiate_device_flow(self, scopes=None, **kwargs):
         """Initiate a Device Flow instance,

--- a/msal/application.py
+++ b/msal/application.py
@@ -418,11 +418,12 @@ class ClientApplication(object):
         :param boolean allow_broker:
             Brokers provide Single-Sign-On, device identification,
             and application identification verification.
+            This flag defaults to None, which means MSAL will not utilize broker.
             If this parameter is set to True,
-            MSAL will use the broker and return either a token or an error,
-            when your scenario is supported by a broker,
-            otherwise it will automatically fall back to non-broker behavior.
-            This also means you could set this flag as True universally,
+            MSAL will use the broker whenever possible,
+            and automatically fall back to non-broker behavior.
+            That also means your app does not need to enable broker conditionally,
+            you can always set allow_broker to True,
             as long as your app meets the following prerequisite:
 
             * Installed optional dependency, e.g. ``pip install msal[broker]>=1.20,<2``.

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -72,9 +72,10 @@ class Authority(object):
             authority_url = str(authority_url)
         authority, self.instance, tenant = canonicalize(authority_url)
         parts = authority.path.split('/')
-        is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or (
+        self._is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or (
             len(parts) == 3 and parts[2].lower().startswith("b2c_"))
-        if (tenant != "adfs" and (not is_b2c) and validate_authority
+        self._validate_authority = True if validate_authority is None else bool(validate_authority)
+        if (tenant != "adfs" and (not self._is_b2c) and self._validate_authority
                 and self.instance not in WELL_KNOWN_AUTHORITY_HOSTS):
             payload = instance_discovery(
                 "https://{}{}/oauth2/v2.0/authorize".format(

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -144,7 +144,7 @@ def _signin_silently(
 def _signin_interactively(
         authority, client_id, scopes,
         parent_window_handle,  # None means auto-detect for console apps
-        prompt=None,
+        prompt=None,  # Note: This function does not really use this parameter
         login_hint=None,
         claims=None,
         correlation_id=None,

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -90,8 +90,7 @@ def _convert_result(result, client_id, expected_token_type=None):  # Mimic an on
     id_token_claims = json.loads(result.get_id_token()) if result.get_id_token() else {}
     account = result.get_account()
     assert account, "Account is expected to be always available"
-    ## Note: As of pymsalruntime 0.1.0, only wam_account_ids property is available
-    #account.get_account_property("wam_account_ids")
+    # Note: There are more account attribute getters available in pymsalruntime 0.13+
     return_value = {k: v for k, v in {
         "access_token": result.get_access_token(),
         "expires_in": result.get_access_token_expiry_time() - int(time.time()),  # Convert epoch to count-down

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -10,8 +10,7 @@ import uuid
 
 logger = logging.getLogger(__name__)
 try:
-    import pymsalruntime  # ImportError would be raised on unsupported platforms such as Windows 8
-    # Its API description is available in site-packages/pymsalruntime/PyMsalRuntime.pyi
+    import pymsalruntime  # Its API description is available in site-packages/pymsalruntime/PyMsalRuntime.pyi
     pymsalruntime.register_logging_callback(lambda message, level: {  # New in pymsalruntime 0.7
         pymsalruntime.LogLevel.TRACE: logger.debug,  # Python has no TRACE level
         pymsalruntime.LogLevel.DEBUG: logger.debug,
@@ -26,7 +25,7 @@ except (ImportError, AttributeError):  # AttributeError happens when a prior pym
     # https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/2406/files
     raise ImportError(  # TODO: Remove or adjust this line right before merging this PR
         'You need to install dependency by: pip install "msal[broker]>=1.20.0b1,<2"')
-# Other exceptions (possibly RuntimeError) would be raised if its initialization fails
+# It could throw RuntimeError when running on ancient versions of Windows
 
 
 class RedirectUriError(ValueError):

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -1,0 +1,239 @@
+"""This module is an adaptor to the underlying broker.
+It relies on PyMsalRuntime which is the package providing broker's functionality.
+"""
+from threading import Event
+import json
+import logging
+import time
+import uuid
+
+
+logger = logging.getLogger(__name__)
+try:
+    import pymsalruntime  # ImportError would be raised on unsupported platforms such as Windows 8
+    # Its API description is available in site-packages/pymsalruntime/PyMsalRuntime.pyi
+    pymsalruntime.register_logging_callback(lambda message, level: {  # New in pymsalruntime 0.7
+        pymsalruntime.LogLevel.TRACE: logger.debug,  # Python has no TRACE level
+        pymsalruntime.LogLevel.DEBUG: logger.debug,
+        # Let broker's excess info, warning and error logs map into default DEBUG, for now
+        #pymsalruntime.LogLevel.INFO: logger.info,
+        #pymsalruntime.LogLevel.WARNING: logger.warning,
+        #pymsalruntime.LogLevel.ERROR: logger.error,
+        pymsalruntime.LogLevel.FATAL: logger.critical,
+        }.get(level, logger.debug)(message))
+except (ImportError, AttributeError):  # AttributeError happens when a prior pymsalruntime uninstallation somehow leaved an empty folder behind
+    # PyMsalRuntime currently supports these Windows versions, listed in this MSFT internal link
+    # https://github.com/AzureAD/microsoft-authentication-library-for-cpp/pull/2406/files
+    raise ImportError(  # TODO: Remove or adjust this line right before merging this PR
+        'You need to install dependency by: pip install "msal[broker]>=1.20.0b1,<2"')
+# Other exceptions (possibly RuntimeError) would be raised if its initialization fails
+
+
+class RedirectUriError(ValueError):
+    pass
+
+
+class TokenTypeError(ValueError):
+    pass
+
+
+class _CallbackData:
+    def __init__(self):
+        self.signal = Event()
+        self.result = None
+
+    def complete(self, result):
+        self.signal.set()
+        self.result = result
+
+
+def _convert_error(error, client_id):
+    context = error.get_context()  # Available since pymsalruntime 0.0.4
+    if (
+            "AADSTS50011" in context  # In WAM, this could happen on both interactive and silent flows
+            or "AADSTS7000218" in context  # This "request body must contain ... client_secret" is just a symptom of current app has no WAM redirect_uri
+            ):
+        raise RedirectUriError(  # This would be seen by either the app developer or end user
+            "MsalRuntime won't work unless this one more redirect_uri is registered to current app: "
+            "ms-appx-web://Microsoft.AAD.BrokerPlugin/{}".format(client_id))
+        # OTOH, AAD would emit other errors when other error handling branch was hit first,
+        # so, the AADSTS50011/RedirectUriError is not guaranteed to happen.
+    return {
+        "error": "broker_error",  # Note: Broker implies your device needs to be compliant.
+            # You may use "dsregcmd /status" to check your device state
+            # https://docs.microsoft.com/en-us/azure/active-directory/devices/troubleshoot-device-dsregcmd
+        "error_description": "{}. Status: {}, Error code: {}, Tag: {}".format(
+            context,
+            error.get_status(), error.get_error_code(), error.get_tag()),
+        "_broker_status": error.get_status(),
+        "_broker_error_code": error.get_error_code(),
+        "_broker_tag": error.get_tag(),
+        }
+
+
+def _read_account_by_id(account_id, correlation_id):
+    """Return an instance of MSALRuntimeError or MSALRuntimeAccount, or None"""
+    callback_data = _CallbackData()
+    pymsalruntime.read_account_by_id(
+        account_id,
+        correlation_id,
+        lambda result, callback_data=callback_data: callback_data.complete(result)
+        )
+    callback_data.signal.wait()
+    return (callback_data.result.get_error() or callback_data.result.get_account()
+        or None)  # None happens when the account was not created by broker
+
+
+def _convert_result(result, client_id, expected_token_type=None):  # Mimic an on-the-wire response from AAD
+    error = result.get_error()
+    if error:
+        return _convert_error(error, client_id)
+    id_token_claims = json.loads(result.get_id_token()) if result.get_id_token() else {}
+    account = result.get_account()
+    assert account, "Account is expected to be always available"
+    ## Note: As of pymsalruntime 0.1.0, only wam_account_ids property is available
+    #account.get_account_property("wam_account_ids")
+    return_value = {k: v for k, v in {
+        "access_token": result.get_access_token(),
+        "expires_in": result.get_access_token_expiry_time() - int(time.time()),  # Convert epoch to count-down
+        "id_token": result.get_raw_id_token(),  # New in pymsalruntime 0.8.1
+        "id_token_claims": id_token_claims,
+        "client_info": account.get_client_info(),
+        "_account_id": account.get_account_id(),
+		"token_type": expected_token_type or "Bearer",  # Workaround its absence from broker
+        }.items() if v}
+    likely_a_cert = return_value["access_token"].startswith("AAAA")  # Empirical observation
+    if return_value["token_type"].lower() == "ssh-cert" and not likely_a_cert:
+        raise TokenTypeError("Broker could not get an SSH Cert: {}...".format(
+            return_value["access_token"][:8]))
+    granted_scopes = result.get_granted_scopes()  # New in pymsalruntime 0.3.x
+    if granted_scopes:
+        return_value["scope"] = " ".join(granted_scopes)  # Mimic the on-the-wire data format
+    return return_value
+
+
+def _get_new_correlation_id():
+    return str(uuid.uuid4())
+
+
+def _enable_msa_pt(params):
+    params.set_additional_parameter("msal_request_type", "consumer_passthrough")  # PyMsalRuntime 0.8+
+
+
+def _signin_silently(
+        authority, client_id, scopes, correlation_id=None, claims=None,
+        enable_msa_pt=False,
+        **kwargs):
+    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params.set_requested_scopes(scopes)
+    if claims:
+        params.set_decoded_claims(claims)
+    callback_data = _CallbackData()
+    for k, v in kwargs.items():  # This can be used to support domain_hint, max_age, etc.
+        if v is not None:
+            params.set_additional_parameter(k, str(v))
+    if enable_msa_pt:
+        _enable_msa_pt(params)
+    pymsalruntime.signin_silently(
+        params,
+        correlation_id or _get_new_correlation_id(),
+        lambda result, callback_data=callback_data: callback_data.complete(result))
+    callback_data.signal.wait()
+    return _convert_result(
+        callback_data.result, client_id, expected_token_type=kwargs.get("token_type"))
+
+
+def _signin_interactively(
+        authority, client_id, scopes,
+        parent_window_handle,  # None means auto-detect for console apps
+        prompt=None,
+        login_hint=None,
+        claims=None,
+        correlation_id=None,
+        enable_msa_pt=False,
+        **kwargs):
+    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params.set_requested_scopes(scopes)
+    params.set_redirect_uri("placeholder")  # pymsalruntime 0.1 requires non-empty str,
+        # the actual redirect_uri will be overridden by a value hardcoded by the broker
+    if prompt:
+        if prompt == "select_account":
+            if login_hint:
+                # FWIW, AAD's browser interactive flow would honor select_account
+                # and ignore login_hint in such a case.
+                # But pymsalruntime 0.3.x would pop up a meaningless account picker
+                # and then force the account_hint user to re-input password. Not what we want.
+                # https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1744492
+                login_hint = None  # Mimicing the AAD behavior
+                logger.warning("Using both select_account and login_hint is ambiguous. Ignoring login_hint.")
+        else:
+            logger.warning("prompt=%s is not supported by this module", prompt)
+    if parent_window_handle is None:
+        # This fixes account picker hanging in IDE debug mode on some machines
+        params.set_additional_parameter("msal_gui_thread", "true")  # Since pymsalruntime 0.8.1
+    if enable_msa_pt:
+        _enable_msa_pt(params)
+    for k, v in kwargs.items():  # This can be used to support domain_hint, max_age, etc.
+        if v is not None:
+            params.set_additional_parameter(k, str(v))
+    if claims:
+        params.set_decoded_claims(claims)
+    callback_data = _CallbackData()
+    pymsalruntime.signin_interactively(
+        parent_window_handle or pymsalruntime.get_console_window() or pymsalruntime.get_desktop_window(),  # Since pymsalruntime 0.2+
+        params,
+        correlation_id or _get_new_correlation_id(),
+        login_hint,  # None value will be accepted since pymsalruntime 0.3+
+        lambda result, callback_data=callback_data: callback_data.complete(result))
+    callback_data.signal.wait()
+    return _convert_result(
+        callback_data.result, client_id, expected_token_type=kwargs.get("token_type"))
+
+
+def _acquire_token_silently(
+        authority, client_id, account_id, scopes, claims=None, correlation_id=None,
+        **kwargs):
+    # For MSA PT scenario where you use the /organizations, yes,
+    # acquireTokenSilently is expected to fail.  - Sam Wilson
+    correlation_id = correlation_id or _get_new_correlation_id()
+    account = _read_account_by_id(account_id, correlation_id)
+    if isinstance(account, pymsalruntime.MSALRuntimeError):
+        return _convert_error(account, client_id)
+    if account is None:
+        return
+    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params.set_requested_scopes(scopes)
+    if claims:
+        params.set_decoded_claims(claims)
+    for k, v in kwargs.items():  # This can be used to support domain_hint, max_age, etc.
+        if v is not None:
+            params.set_additional_parameter(k, str(v))
+    callback_data = _CallbackData()
+    pymsalruntime.acquire_token_silently(
+        params,
+        correlation_id,
+        account,
+        lambda result, callback_data=callback_data: callback_data.complete(result))
+    callback_data.signal.wait()
+    return _convert_result(
+        callback_data.result, client_id, expected_token_type=kwargs.get("token_type"))
+
+
+def _signout_silently(client_id, account_id, correlation_id=None):
+    correlation_id = correlation_id or _get_new_correlation_id()
+    account = _read_account_by_id(account_id, correlation_id)
+    if isinstance(account, pymsalruntime.MSALRuntimeError):
+        return _convert_error(account, client_id)
+    if account is None:
+        return
+    callback_data = _CallbackData()
+    pymsalruntime.signout_silently(  # New in PyMsalRuntime 0.7
+        client_id,
+        correlation_id,
+        account,
+        lambda result, callback_data=callback_data: callback_data.complete(result))
+    callback_data.signal.wait()
+    error = callback_data.result.get_error()
+    if error:
+        return _convert_error(error, client_id)
+

--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -12,6 +12,10 @@ logger = logging.getLogger(__name__)
 def is_subdict_of(small, big):
     return dict(big, **small) == big
 
+def _get_username(id_token_claims):
+    return id_token_claims.get(
+        "preferred_username",  # AAD
+        id_token_claims.get("upn"))  # ADFS 2019
 
 class TokenCache(object):
     """This is considered as a base class containing minimal cache behavior.
@@ -149,10 +153,9 @@ class TokenCache(object):
         access_token = response.get("access_token")
         refresh_token = response.get("refresh_token")
         id_token = response.get("id_token")
-        id_token_claims = (
-            decode_id_token(id_token, client_id=event["client_id"])
-            if id_token
-            else response.get("id_token_claims", {}))  # Broker would provide id_token_claims
+        id_token_claims = response.get("id_token_claims") or (  # Prefer the claims from broker
+            # Only use decode_id_token() when necessary, it contains time-sensitive validation
+            decode_id_token(id_token, client_id=event["client_id"]) if id_token else {})
         client_info, home_account_id = self.__parse_account(response, id_token_claims)
 
         target = ' '.join(event.get("scope") or [])  # Per schema, we don't sort it
@@ -190,10 +193,11 @@ class TokenCache(object):
                     "home_account_id": home_account_id,
                     "environment": environment,
                     "realm": realm,
-                    "local_account_id": id_token_claims.get(
-                        "oid", id_token_claims.get("sub")),
-                    "username": id_token_claims.get("preferred_username")  # AAD
-                        or id_token_claims.get("upn")  # ADFS 2019
+                    "local_account_id": event.get(
+                        "_account_id",  # Came from mid-tier code path.
+                            # Emperically, it is the oid in AAD or cid in MSA.
+                        id_token_claims.get("oid", id_token_claims.get("sub"))),
+                    "username": _get_username(id_token_claims)
                         or data.get("username")  # Falls back to ROPC username
                         or event.get("username")  # Falls back to Federated ROPC username
                         or "",  # The schema does not like null

--- a/sample/interactive_sample.py
+++ b/sample/interactive_sample.py
@@ -1,4 +1,7 @@
 """
+Prerequisite is documented here:
+https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.acquire_token_interactive
+
 The configuration file would look like this:
 
 {
@@ -30,6 +33,8 @@ config = json.load(open(sys.argv[1]))
 # Create a preferably long-lived app instance which maintains a token cache.
 app = msal.PublicClientApplication(
     config["client_id"], authority=config["authority"],
+    #allow_broker=True,  # If opted in, you will be guided to meet the prerequisites, when applicable
+                         # See also: https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-wam#wam-value-proposition
     # token_cache=...  # Default cache is in memory only.
                        # You can learn how to use SerializableTokenCache from
                        # https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache
@@ -55,6 +60,7 @@ if not result:
     print("A local browser window will be open for you to sign in. CTRL+C to cancel.")
     result = app.acquire_token_interactive(  # Only works if your app is registered with redirect_uri as http://localhost
         config["scope"],
+        #parent_window_handle=...,  # If broker is enabled, you will be guided to provide a window handle
         login_hint=config.get("username"),  # Optional.
             # If you know the username ahead of time, this parameter can pre-fill
             # the username (or email address) field of the sign-in page for the user,

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
             # The broker is defined as optional dependency,
             # so that downstream apps can opt in. The opt-in is needed, partially because
             # most existing MSAL Python apps do not have the redirect_uri needed by broker.
-            "pymsalruntime>=0.11.2,<0.12;python_version>='3.6' and platform_system=='Windows'",
+            "pymsalruntime>=0.11.2,<0.14;python_version>='3.6' and platform_system=='Windows'",
             ],
         },
 )

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,14 @@ setup(
             # https://cryptography.io/en/latest/api-stability/#deprecation
 
         "mock;python_version<'3.3'",
-    ]
+        ],
+    extras_require={  # It does not seem to work if being defined inside setup.cfg
+        "broker": [
+            # The broker is defined as optional dependency,
+            # so that downstream apps can opt in. The opt-in is needed, partially because
+            # most existing MSAL Python apps do not have the redirect_uri needed by broker.
+            "pymsalruntime>=0.11.2,<0.12;python_version>='3.6' and platform_system=='Windows'",
+            ],
+        },
 )
 

--- a/tests/msaltest.py
+++ b/tests/msaltest.py
@@ -1,6 +1,9 @@
 import getpass, logging, pprint, sys, msal
 
 
+AZURE_CLI = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+VISUAL_STUDIO = "04f0c124-f2bc-4f59-8241-bf6df9866bbd"
+
 def _input_boolean(message):
     return input(
         "{} (N/n/F/f or empty means False, otherwise it is True): ".format(message)
@@ -81,6 +84,9 @@ def _acquire_token_interactive(app, scopes, data=None):
     result = app.acquire_token_interactive(
         scopes,
         parent_window_handle=app.CONSOLE_WINDOW_HANDLE,  # This test app is a console app
+        enable_msa_passthrough=app.client_id in [  # Apps are expected to set this right
+            AZURE_CLI, VISUAL_STUDIO,
+            ],  # Here this test app mimics the setting for some known MSA-PT apps
         prompt=prompt, login_hint=login_hint, data=data or {})
     if login_hint and "id_token_claims" in result:
         signed_in_user = result.get("id_token_claims", {}).get("preferred_username")
@@ -142,8 +148,8 @@ def exit(app):
 def main():
     print("Welcome to the Msal Python Console Test App, committed at 2022-5-2\n")
     chosen_app = _select_options([
-        {"client_id": "04b07795-8ddb-461a-bbee-02f9e1bf7b46", "name": "Azure CLI (Correctly configured for MSA-PT)"},
-        {"client_id": "04f0c124-f2bc-4f59-8241-bf6df9866bbd", "name": "Visual Studio (Correctly configured for MSA-PT)"},
+        {"client_id": AZURE_CLI, "name": "Azure CLI (Correctly configured for MSA-PT)"},
+        {"client_id": VISUAL_STUDIO, "name": "Visual Studio (Correctly configured for MSA-PT)"},
         {"client_id": "95de633a-083e-42f5-b444-a4295d8e9314", "name": "Whiteboard Services (Non MSA-PT app. Accepts AAD & MSA accounts.)"},
         ],
         option_renderer=lambda a: a["name"],

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,63 @@
+from tests import unittest
+import logging
+import sys
+
+if not sys.platform.startswith("win"):
+    raise unittest.SkipTest("Currently, our broker supports Windows")
+from msal.broker import (  # Import them after the platform check
+    _signin_silently, _signin_interactively, _acquire_token_silently, RedirectUriError,
+    _signout_silently, _read_account_by_id,
+    )
+
+
+logging.basicConfig(level=logging.DEBUG)
+
+class BrokerTestCase(unittest.TestCase):
+    """These are the unit tests for the thin broker.py layer.
+
+    It currently hardcodes some test apps which might be changed/gone in the future.
+    The existing test_e2e.py is sophisticated to pull test configuration securely from lab.
+    """
+    _client_id = "04f0c124-f2bc-4f59-8241-bf6df9866bbd"  # Visual Studio
+    _authority = "https://login.microsoftonline.com/common"
+    _scopes = ["https://graph.microsoft.com/.default"]
+
+    def test_signin_interactive_then_acquire_token_silent_then_signout(self):
+        result = _signin_interactively(self._authority, self._client_id, self._scopes, None)
+        self.assertIsNotNone(result.get("access_token"), result)
+
+        account_id = result["_account_id"]
+        self.assertIsNotNone(_read_account_by_id(account_id, "correlation_id"))
+        result = _acquire_token_silently(
+                self._authority, self._client_id, account_id, self._scopes)
+        self.assertIsNotNone(result.get("access_token"), result)
+
+        signout_error = _signout_silently(self._client_id, account_id)
+        self.assertIsNone(signout_error, msg=signout_error)
+        account = _read_account_by_id(account_id, "correlation_id")
+        self.assertIsNotNone(account, msg="pymsalruntime still has this account")
+        result = _acquire_token_silently(
+                self._authority, self._client_id, account_id, self._scopes)
+        self.assertIn("Status_AccountUnusable", result.get("error_description", ""))
+
+    def test_unconfigured_app_should_raise_exception(self):
+        app_without_needed_redirect_uri = "289a413d-284b-4303-9c79-94380abe5d22"
+        with self.assertRaises(RedirectUriError):
+            _signin_interactively(
+                self._authority, app_without_needed_redirect_uri, self._scopes, None)
+        # Note: _acquire_token_silently() would raise same exception,
+        #       we skip its test here due to the lack of a valid account_id
+
+    def test_signin_interactively_and_select_account(self):
+        print("An account picker UI will pop up. See whether the auth result matches your account")
+        result = _signin_interactively(
+            self._authority, self._client_id, self._scopes, None, prompt="select_account")
+        self.assertIsNotNone(result.get("access_token"), result)
+        if "access_token" in result:
+            result["access_token"] = "********"
+        import pprint; pprint.pprint(result)
+
+    def test_signin_silently(self):
+        result = _signin_silently(self._authority, self._client_id, self._scopes)
+        self.assertIsNotNone(result.get("access_token"), result)
+

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -54,6 +54,25 @@ def _get_app_and_auth_code(
     assert ac is not None
     return (app, ac, redirect_uri)
 
+def _render(url, description=None):
+    # Render a url in html if description is available, otherwise return url as-is
+    return "<a href='{url}' target=_blank>{description}</a>".format(
+        url=url, description=description) if description else url
+
+
+def _get_hint(html_mode=None, username=None, lab_name=None, username_uri=None):
+    return "Sign in with {user} whose password is available from {lab}".format(
+        user=("<b>{}</b>".format(username) if html_mode else username)
+            if username
+            else "the upn from {}".format(_render(
+                username_uri, description="here" if html_mode else None)),
+        lab=_render(
+            "https://aka.ms/GetLabUserSecret?Secret=" + (lab_name or "msidlabXYZ"),
+            description="this password api" if html_mode else None,
+            ),
+        )
+
+
 @unittest.skipIf(os.getenv("TRAVIS_TAG"), "Skip e2e tests during tagged release")
 class E2eTestCase(unittest.TestCase):
 
@@ -212,25 +231,31 @@ class E2eTestCase(unittest.TestCase):
 
     def _test_acquire_token_interactive(
             self, client_id=None, authority=None, scope=None, port=None,
-            username_uri="",  # But you would want to provide one
+            username=None, lab_name=None,
+            username_uri="",  # Unnecessary if you provided username and lab_name
             data=None,  # Needed by ssh-cert feature
             prompt=None,
+            enable_msa_passthrough=None,
             **ignored):
         assert client_id and authority and scope
         self.app = self._build_app(client_id, authority=authority)
+        logger.info(_get_hint(  # Useful when testing broker which shows no welcome_template
+            username=username, lab_name=lab_name, username_uri=username_uri))
         result = self.app.acquire_token_interactive(
             scope,
+            login_hint=username,
             prompt=prompt,
             timeout=120,
             port=port,
             parent_window_handle=self.app.CONSOLE_WINDOW_HANDLE,  # This test app is a console app
+            enable_msa_passthrough=enable_msa_passthrough,  # Needed when testing MSA-PT app
             welcome_template=  # This is an undocumented feature for testing
                 """<html><body><h1>{id}</h1><ol>
-    <li>Get a username from the upn shown at <a href="{username_uri}">here</a></li>
-    <li>Get its password from https://aka.ms/GetLabUserSecret?Secret=msidlabXYZ
-        (replace the lab name with the labName from the link above).</li>
+    <li>{hint}</li>
     <li><a href="$auth_uri">Sign In</a> or <a href="$abort_uri">Abort</a></li>
-    </ol></body></html>""".format(id=self.id(), username_uri=username_uri),
+    </ol></body></html>""".format(id=self.id(), hint=_get_hint(
+                html_mode=True,
+                username=username, lab_name=lab_name, username_uri=username_uri)),
             data=data or {},
             )
         self.assertIn(
@@ -239,6 +264,11 @@ class E2eTestCase(unittest.TestCase):
                 # Note: No interpolation here, cause error won't always present
                 error=result.get("error"),
                 error_description=result.get("error_description")))
+        if username and result.get("id_token_claims", {}).get("preferred_username"):
+            self.assertEqual(
+                username, result["id_token_claims"]["preferred_username"],
+                "You are expected to sign in as account {}, but tokens returned is for {}".format(
+                    username, result["id_token_claims"]["preferred_username"]))
         self.assertCacheWorksForUser(result, scope, username=None, data=data or {})
         return result  # For further testing
 
@@ -260,7 +290,7 @@ class SshCertTestCase(E2eTestCase):
         self.assertEqual("ssh-cert", result["token_type"])
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
-    def test_ssh_cert_for_user(self):
+    def test_ssh_cert_for_user_should_work_with_any_account(self):
         result = self._test_acquire_token_interactive(
             client_id="04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Azure CLI is one
                 # of the only 2 clients that are PreAuthz to use ssh cert feature
@@ -555,7 +585,8 @@ class LabBasedTestCase(E2eTestCase):
 
     def _test_acquire_token_by_auth_code_flow(
             self, client_id=None, authority=None, port=None, scope=None,
-            username_uri="",  # But you would want to provide one
+            username=None, lab_name=None,
+            username_uri="",  # Optional if you provided username and lab_name
             **ignored):
         assert client_id and authority and scope
         self.app = msal.ClientApplication(
@@ -568,11 +599,11 @@ class LabBasedTestCase(E2eTestCase):
             auth_response = receiver.get_auth_response(
                 auth_uri=flow["auth_uri"], state=flow["state"], timeout=60,
                 welcome_template="""<html><body><h1>{id}</h1><ol>
-    <li>Get a username from the upn shown at <a href="{username_uri}">here</a></li>
-    <li>Get its password from https://aka.ms/GetLabUserSecret?Secret=msidlabXYZ
-        (replace the lab name with the labName from the link above).</li>
+    <li>{hint}</li>
     <li><a href="$auth_uri">Sign In</a> or <a href="$abort_uri">Abort</a></li>
-    </ol></body></html>""".format(id=self.id(), username_uri=username_uri),
+    </ol></body></html>""".format(id=self.id(), hint=_get_hint(
+                    html_mode=True,
+                    username=username, lab_name=lab_name, username_uri=username_uri)),
                 )
         if auth_response is None:
             self.skipTest("Timed out. Did not have test settings in hand? Prepare and retry.")
@@ -592,6 +623,11 @@ class LabBasedTestCase(E2eTestCase):
                 # Note: No interpolation here, cause error won't always present
                 error=result.get("error"),
                 error_description=result.get("error_description")))
+        if username and result.get("id_token_claims", {}).get("preferred_username"):
+            self.assertEqual(
+                username, result["id_token_claims"]["preferred_username"],
+                "You are expected to sign in as account {}, but tokens returned is for {}".format(
+                    username, result["id_token_claims"]["preferred_username"]))
         self.assertCacheWorksForUser(result, scope, username=None)
 
     def _test_acquire_token_obo(self, config_pca, config_cca,
@@ -689,10 +725,23 @@ class WorldWideTestCase(LabBasedTestCase):
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
     def test_cloud_acquire_token_interactive(self):
-        config = self.get_lab_user(usertype="cloud")
-        self._test_acquire_token_interactive(
-            username_uri="https://msidlab.com/api/user?usertype=cloud",
-            **config)
+        self._test_acquire_token_interactive(**self.get_lab_user(usertype="cloud"))
+
+    @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
+    def test_msa_pt_app_signin_via_organizations_authority_without_login_hint(self):
+        """There is/was an upstream bug. See test case full docstring for the details.
+
+        When a MSAL-PT flow that account control is launched, user has 2+ AAD accounts in WAM,
+        selects an AAD account that is NOT the default AAD account from the OS,
+        it will incorrectly get tokens for default AAD account.
+        """
+        self._test_acquire_token_interactive(**dict(
+            self.get_lab_user(usertype="cloud"),  # This is generally not the current laptop's default AAD account
+            authority="https://login.microsoftonline.com/organizations",
+            client_id="04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Azure CLI is an MSA-PT app
+            enable_msa_passthrough=True,
+            prompt="select_account",  # In MSAL Python, this resets login_hint
+            ))
 
     def test_ropc_adfs2019_onprem(self):
         # Configuration is derived from https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.7.0/tests/Microsoft.Identity.Test.Common/TestConstants.cs#L250-L259
@@ -719,22 +768,22 @@ class WorldWideTestCase(LabBasedTestCase):
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
     def test_adfs2019_onprem_acquire_token_by_auth_code_flow(self):
         config = self.get_lab_user(usertype="onprem", federationProvider="ADFSv2019")
-        config["authority"] = "https://fs.%s.com/adfs" % config["lab_name"]
-        config["scope"] = self.adfs2019_scopes
-        config["port"] = 8080
-        self._test_acquire_token_by_auth_code_flow(
-            username_uri="https://msidlab.com/api/user?usertype=onprem&federationprovider=ADFSv2019",
-            **config)
+        self._test_acquire_token_by_auth_code_flow(**dict(
+            config,
+            authority="https://fs.%s.com/adfs" % config["lab_name"],
+            scope=self.adfs2019_scopes,
+            port=8080,
+            ))
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
     def test_adfs2019_onprem_acquire_token_interactive(self):
         config = self.get_lab_user(usertype="onprem", federationProvider="ADFSv2019")
-        config["authority"] = "https://fs.%s.com/adfs" % config["lab_name"]
-        config["scope"] = self.adfs2019_scopes
-        config["port"] = 8080
-        self._test_acquire_token_interactive(
-            username_uri="https://msidlab.com/api/user?usertype=onprem&federationprovider=ADFSv2019",
-            **config)
+        self._test_acquire_token_interactive(**dict(
+            config,
+            authority="https://fs.%s.com/adfs" % config["lab_name"],
+            scope=self.adfs2019_scopes,
+            port=8080,
+            ))
 
     @unittest.skipUnless(
         os.getenv("LAB_OBO_CLIENT_SECRET"),
@@ -816,14 +865,12 @@ class WorldWideTestCase(LabBasedTestCase):
 
     @unittest.skipIf(os.getenv("TRAVIS"), "Browser automation is not yet implemented")
     def test_b2c_acquire_token_by_auth_code_flow(self):
-        config = self.get_lab_app_object(azureenvironment="azureb2ccloud")
-        self._test_acquire_token_by_auth_code_flow(
+        self._test_acquire_token_by_auth_code_flow(**dict(
+            self.get_lab_user(usertype="b2c", b2cprovider="local"),
             authority=self._build_b2c_authority("B2C_1_SignInPolicy"),
-            client_id=config["appId"],
             port=3843,  # Lab defines 4 of them: [3843, 4584, 4843, 60000]
-            scope=config["scopes"],
-            username_uri="https://msidlab.com/api/user?usertype=b2c&b2cprovider=local",
-            )
+            scope=self.get_lab_app_object(azureenvironment="azureb2ccloud")["scopes"],
+            ))
 
     def test_b2c_acquire_token_by_ropc(self):
         config = self.get_lab_app_object(azureenvironment="azureb2ccloud")


### PR DESCRIPTION
## What is this?

A broker is a component installed on your device. Broker implicitly gives your device an identity. By using a broker, your device becomes a factor that can satisfy MFA (Multi-factor authentication). This factor would become mandatory if/when a tenant's admin enables a corresponding Conditional Access (CA) policy. The broker's presence allows Microsoft identity platform to have higher confidence that the tokens are being issued to your device, and that is more secure. 

An additional benefit of broker is, it runs as a long-lived process with your device's OS, and maintains its own cache, so that your broker-enabled apps (even CLI) could automatically SSO from a previously established signed-in session.

Currently, broker is available on recent Windows platforms.

In this PR, MSAL Python utilizes the broker to acquire tokens. When enabled, broker behaviors will kick in when your `PublicClientApplication` app calls MSAL Python's `acquire_token_interactive()`, `acquire_token_by_username_password()`, `acquire_token_silent()`, `acquire_token_silent_with_error()`. Most noticeably, the `acquire_token_interactive([...], prompt="select_account")` will trigger a pop-up window, rather than a browser.

API reference docs has also been updated and staged at [here](https://msal-python.readthedocs.io/en/docs-staging/#msal.PublicClientApplication.acquire_token_by_auth_code_flow) (you would need to scroll up a little bit).

## Prerequisite for an app

0. Because this feature branch is not yet officially released with a version number, you will need to clean up your test environment by `pip uninstall msal pymsalruntime -y`, especially when you want to reset your test environment to test the latest changes in this PR.

1. Use a recent version of MSAL Python.
    Currently, this can be achieved by installing the MSAL Python from this feature branch:
    `pip install "git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@wam"`

2. Install the broker package.
   The [broker package `pymsalruntime`](https://pypi.org/project/pymsalruntime/) needs to be available in your Python environment, ~so that MSAL Python will automatically utilize it~. This can be satisfied by `pip install "msal[broker] @ git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@wam"`. <sub>In the future (after this PR is merged and shipped), your app can meet the two prerequisites above by a simpler `pip install "msal[broker]>=1.19,<2"` (The actual release version is not yet determined.)</sub>.
   (We do NOT recommend directly install `pymsalruntime`, because its latest version may not have been tested with MSAL Python. Stick with the installation command above so that you will always get the latest version of `pymsalruntime` which has been tested with MSAL Python.)

3. Register one more redirect URI.
   Your app would need to register this one more `redirect_uri` beforehand, in this form: `ms-appx-web://Microsoft.AAD.BrokerPlugin/your_client_id`.

4. Opt-in.
   ~Currently, MSAL Python does not provide an API-level opt-in flag. App developer opts in by declaring needed dependencies AND registering a new redirect URL. Once all prerequisites are met, broker behavior will kick in, otherwise, it will gracefully be fallback to use non-broker behavior. The idea is your app does not need to hardcode your opt-in/opt-out decision, or to implement an opt-in or opt-out setting. The broker functionality can be toggled flexibly, without any source code changes to your app. This approach would make the adoption easier.~
   Opt-in by `PublicClientApplication(..., allow_broker=True)`.

## Action items for a downstream library

* As a library, the prerequisite No. 3 is not applicable to you
* ~You do not need any source code changes to your library~. You would need to somehow expose prerequisite No.4 `allow_broker=True or False` to your app developers.
* There is also one new optional parameter `acquire_token_interactive(..., window=...)`. It is [documented here](https://msal-python.readthedocs.io/en/docs-staging/#msal.PublicClientApplication.acquire_token_interactive).
* Optionally, you may consider also expose a `[broker]` option which internally makes dependency on `msal[broker]`, so that your downstream apps could use `pip install YourLibrary[broker]` to pull in the dependencies for Microsoft identity platform's broker behavior. Or you simply declare `msal[broker]...` as a required dependency.

Regardless, you would still want to use your own test app to test the broker behavior to understand its impact on your library's experience.


## What/How to test

* Test script is available for [download here](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/wam/tests/msaltest.py) and then run it by `python msaltest.py`.
  (Alternatively, you can use this MSAL Python's interactive sample, add the `allow_broker=True` flag, and then uncomment [this line](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.18.0/sample/interactive_sample.py#L65), to force a broker-powered pop-up window for authentication. Without changing that line, broker would still work, but it would silently use your already-signed-in account in your subsequent test runs, so it will be less tangible.)

* Test this statement: "When an app does not yet ~register the broker-specific redirect_uri~ set `allow_broker=True`, installing the new MSAL Python and the broker package `pymsalruntime` should *not* cause authentication failure".

  | 1. Use recent MSAL Python | 2. Install dependency (The environment contains `pymsalruntime`) | 3. App registers a new `redirect_uri` | 4. Opt-in | Expected behavior (The behaviors implemented in this PR) |
  | --- | --- | --- | --- | --- |
  | No (i.e. using msal<=1.18) | * | * | * | This is the status quo without broker. We use this as a baseline. |
  | Yes (i.e. using this PR) | * | * | False | App should behave the same as before (i.e. above). |
  | Yes (i.e. using this PR) | No | * | True | ~App should behave the same as before (i.e. above).~ Exception will be raised |
  | Yes (i.e. using this PR) | Yes | No | True | MSAL would attempt broker, detect the error, ~emit a warning currently (but we could choose to remove that warning in next commit), and then fall back to use browser/AAD directly~ and raise an exception |
  | Yes (i.e. using this PR) | Yes | Yes | True | MSAL would use broker. Token or error would be returned to the app. More on this below. |

* In particular, when using `acquire_token_interactive(..., prompt="select_account")`, see if you would find any behavior difference between enabling and disabling broker.

  | `allow_broker=False` | `allow_broker=True` | Comment |
  | --- | --- | --- |
  | Successfully obtained an AT | Successfully obtained an AT | This is the happy path |
  | Successfully obtained an AT | Error out | If your app has not met the prerequisite, some errors are expected. That being said, if you encounter some misleading error message, please report back to us. |
  | Error out | Error out | Generally we recommend you to get your app working without broker first. That being said, if you encounter some misleading error message in either case, please report back to us. |

To report an issue, please share with us your test configuration. For example, you can do that by copy and paste the console history of your interaction with our test script `python msaltest.py`.

* Test your app/library can work without a Refresh Token (RT)

  Another subtle change is the absence of refresh token (RT). When an acquire_token request is served by broker, the RT will not be available from the return value. So, if your MSAL-Python-powered app or sdk used to rely on RT to work, you would need to redesign your app/sdk accordingly.


## Roadmap

The following features are not yet supported, but they are expected to be available in the near future. But you should not wait. Please start testing your app with this PR asap, and report back your findings or concerns.

* ~Logging will include broker's debug logs~ Done
* ~Provide support for `max_age` in broker code path~ Done.
* ~Other adjustments in `select_account` and `remove_account()` behavior. But their MSAL Python API are expected to remain unchanged.~ Done.


P.S.:
* Once merged, this PR will resolve #451.
* This is the [internal workitem](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1532789).

CC: @jiasli , @xiangyan99