### PR TITLE
acquire_token_interactive(..., prompt="none") acquires token via Cloud Shell's IMDS-like interface

### DIFF
--- a/msal/cloudshell.py
+++ b/msal/cloudshell.py
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation.
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+
+"""This module wraps Cloud Shell's IMDS-like interface inside an OAuth2-like helper"""
+import base64
+import json
+import logging
+import os
+import time
+try:  # Python 2
+    from urlparse import urlparse
+except:  # Python 3
+    from urllib.parse import urlparse
+from .oauth2cli.oidc import decode_part
+
+
+logger = logging.getLogger(__name__)
+
+
+def _is_running_in_cloud_shell():
+    return os.environ.get("AZUREPS_HOST_ENVIRONMENT", "").startswith("cloud-shell")
+
+
+def _scope_to_resource(scope):  # This is an experimental reasonable-effort approach
+    cloud_shell_supported_audiences = [
+        "https://analysis.windows.net/powerbi/api",  # Came from https://msazure.visualstudio.com/One/_git/compute-CloudShell?path=/src/images/agent/env/envconfig.PROD.json
+        "https://pas.windows.net/CheckMyAccess/Linux/.default",  # Cloud Shell accepts it as-is
+        ]
+    for a in cloud_shell_supported_audiences:
+        if scope.startswith(a):
+            return a
+    u = urlparse(scope)
+    if u.scheme:
+        return "{}://{}".format(u.scheme, u.netloc)
+    return scope  # There is no much else we can do here
+
+
+def _obtain_token(http_client, scopes, client_id=None, data=None):
+    resp = http_client.post(
+        "http://localhost:50342/oauth2/token",
+        data=dict(
+            data or {},
+            resource=" ".join(map(_scope_to_resource, scopes))),
+        headers={"Metadata": "true"},
+        )
+    if resp.status_code >= 300:
+        logger.debug("Cloud Shell IMDS error: %s", resp.text)
+        cs_error = json.loads(resp.text).get("error", {})
+        return {k: v for k, v in {
+            "error": cs_error.get("code"),
+            "error_description": cs_error.get("message"),
+            }.items() if v}
+    imds_payload = json.loads(resp.text)
+    BEARER = "Bearer"
+    oauth2_response = {
+        "access_token": imds_payload["access_token"],
+        "expires_in": int(imds_payload["expires_in"]),
+        "token_type": imds_payload.get("token_type", BEARER),
+        }
+    expected_token_type = (data or {}).get("token_type", BEARER)
+    if oauth2_response["token_type"] != expected_token_type:
+        return {  # Generate a normal error (rather than an intrusive exception)
+            "error": "broker_error",
+            "error_description": "token_type {} is not supported by this version of Azure Portal".format(
+                expected_token_type),
+            }
+    parts = imds_payload["access_token"].split(".")
+
+    # The following default values are useful in SSH Cert scenario
+    client_info = {  # Default value, in case the real value will be unavailable
+        "uid": "user",
+        "utid": "cloudshell",
+        }
+    now = time.time()
+    preferred_username = "currentuser@cloudshell"
+    oauth2_response["id_token_claims"] = {  # First 5 claims are required per OIDC
+        "iss": "cloudshell",
+        "sub": "user",
+        "aud": client_id,
+        "exp": now + 3600,
+        "iat": now,
+        "preferred_username": preferred_username,  # Useful as MSAL account's username
+        }
+
+    if len(parts) == 3:  # Probably a JWT. Use it to derive client_info and id token.
+        try:
+            # Data defined in https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens#payload-claims
+            jwt_payload = json.loads(decode_part(parts[1]))
+            client_info = {
+                # Mimic a real home_account_id,
+                # so that this pseudo account and a real account would interop.
+                "uid": jwt_payload.get("oid", "user"),
+                "utid": jwt_payload.get("tid", "cloudshell"),
+                }
+            oauth2_response["id_token_claims"] = {
+                "iss": jwt_payload["iss"],
+                "sub": jwt_payload["sub"],  # Could use oid instead
+                "aud": client_id,
+                "exp": jwt_payload["exp"],
+                "iat": jwt_payload["iat"],
+                "preferred_username": jwt_payload.get("preferred_username")  # V2
+                    or jwt_payload.get("unique_name")  # V1
+                    or preferred_username,
+                }
+        except ValueError:
+            logger.debug("Unable to decode jwt payload: %s", parts[1])
+    oauth2_response["client_info"] = base64.b64encode(
+        # Mimic a client_info, so that MSAL would create an account
+        json.dumps(client_info).encode("utf-8")).decode("utf-8")
+    oauth2_response["id_token_claims"]["tid"] = client_info["utid"]  # TBD
+
+    ## Note: Decided to not surface resource back as scope,
+    ##       because they would cause the downstream OAuth2 code path to
+    ##       cache the token with a different scope and won't hit them later.
+    #if imds_payload.get("resource"):
+    #    oauth2_response["scope"] = imds_payload["resource"]
+    if imds_payload.get("refresh_token"):
+        oauth2_response["refresh_token"] = imds_payload["refresh_token"]
+    return oauth2_response
+

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -185,12 +185,14 @@ class E2eTestCase(unittest.TestCase):
             self, client_id=None, authority=None, scope=None, port=None,
             username_uri="",  # But you would want to provide one
             data=None,  # Needed by ssh-cert feature
+            prompt=None,
             **ignored):
         assert client_id and authority and scope
         self.app = msal.PublicClientApplication(
             client_id, authority=authority, http_client=MinimalHttpClient())
         result = self.app.acquire_token_interactive(
             scope,
+            prompt=prompt,
             timeout=120,
             port=port,
             welcome_template=  # This is an undocumented feature for testing
@@ -237,6 +239,7 @@ class SshCertTestCase(E2eTestCase):
             scope=self.SCOPE,
             data=self.DATA1,
             username_uri="https://msidlab.com/api/user?usertype=cloud",
+            prompt="none" if msal.application._is_running_in_cloud_shell() else None,
             )   # It already tests reading AT from cache, and using RT to refresh
                 # acquire_token_silent() would work because we pass in the same key
         self.assertIsNotNone(result.get("access_token"), "Encountered {}: {}".format(
@@ -252,6 +255,20 @@ class SshCertTestCase(E2eTestCase):
         self.assertIsNotNone(refreshed_ssh_cert)
         self.assertEqual(refreshed_ssh_cert["token_type"], "ssh-cert")
         self.assertNotEqual(result["access_token"], refreshed_ssh_cert['access_token'])
+
+
+@unittest.skipUnless(
+    msal.application._is_running_in_cloud_shell(),
+    "Manually run this test case from inside Cloud Shell")
+class CloudShellTestCase(E2eTestCase):
+    app = msal.PublicClientApplication("client_id")
+    scope_that_requires_no_managed_device = "https://management.core.windows.net/"  # Scopes came from https://msazure.visualstudio.com/One/_git/compute-CloudShell?path=/src/images/agent/env/envconfig.PROD.json&version=GBmaster&_a=contents
+    def test_access_token_should_be_obtained_for_a_supported_scope(self):
+        result = self.app.acquire_token_interactive(
+            [self.scope_that_requires_no_managed_device], prompt="none")
+        self.assertEqual(
+            "Bearer", result.get("token_type"), "Unexpected result: %s" % result)
+        self.assertIsNotNone(result.get("access_token"))
 
 
 THIS_FOLDER = os.path.dirname(__file__)


### PR DESCRIPTION
The changes in this proof-of-concept is to allow a typical [3-step pattern](https://github.com/AzureAD/microsoft-authentication-library-for-python#usage) MSAL app to automatically utilize the IMDS-like interface when that app happens to be running inside Cloud Shell.

Note to target audience (@jiasli ):

* Starting from 3/1/2022, portal and Cloud Shell have been refactored to allow cert and token acquisition, again, via this test URL:
  `https://rc.portal.azure.com/?feature.sshtokens=true&feature.tokencaching=false#home`
  Currently, portal and Cloud Shell team are still working on the error handling, but that part does not block Azure CLI from integrating this feature branch.
* Currently, the Cloud Shell IMDS-like interface supports only a small set of scopes/resources, such as:
  `https://management.core.windows.net/,https://management.azure.com/,https://graph.windows.net/,...`
* When adopting this feature, Azure CLI would need to remove its existing Cloud Shell code path, and use normal MSAL code path.