### PR TITLE
Define some Cloud Instance constants and the usage pattern of using them

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -231,8 +231,23 @@ class ClientApplication(object):
 
         :param str authority:
             A URL that identifies a token authority. It should be of the format
-            https://login.microsoftonline.com/your_tenant
-            By default, we will use https://login.microsoftonline.com/common
+            ``https://login.microsoftonline.com/your_tenant``
+            By default, we will use ``https://login.microsoftonline.com/common``
+
+            *Changed in version 1.17*: you can also use predefined constant
+            and a builder like this::
+
+                from msal.authority import (
+                    AuthorityBuilder,
+                    AZURE_US_GOVERNMENT, AZURE_CHINA, AZURE_PUBLIC)
+                my_authority = AuthorityBuilder(AZURE_PUBLIC, "contoso.onmicrosoft.com")
+                # Now you get an equivalent of
+                # "https://login.microsoftonline.com/contoso.onmicrosoft.com"
+
+                # You can feed such an authority to msal's ClientApplication
+                from msal import PublicClientApplication
+                app = PublicClientApplication("my_client_id", authority=my_authority, ...)
+
         :param bool validate_authority: (optional) Turns authority validation
             on or off. This parameter default to true.
         :param TokenCache cache:

--- a/tests/http_client.py
+++ b/tests/http_client.py
@@ -20,6 +20,9 @@ class MinimalHttpClient:
         return MinimalResponse(requests_resp=self.session.get(
             url, params=params, headers=headers, timeout=self.timeout))
 
+    def close(self):  # Not required, but we use it to avoid a warning in unit test
+        self.session.close()
+
 
 class MinimalResponse(object):  # Not for production use
     def __init__(self, requests_resp=None, status_code=None, text=None):

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -8,16 +8,37 @@ from tests.http_client import MinimalHttpClient
 @unittest.skipIf(os.getenv("TRAVIS_TAG"), "Skip network io during tagged release")
 class TestAuthority(unittest.TestCase):
 
+    def _test_given_host_and_tenant(self, host, tenant):
+        c = MinimalHttpClient()
+        a = Authority('https://{}/{}'.format(host, tenant), c)
+        self.assertEqual(
+            a.authorization_endpoint,
+            'https://{}/{}/oauth2/v2.0/authorize'.format(host, tenant))
+        self.assertEqual(
+            a.token_endpoint,
+            'https://{}/{}/oauth2/v2.0/token'.format(host, tenant))
+        c.close()
+
+    def _test_authority_builder(self, host, tenant):
+        c = MinimalHttpClient()
+        a = Authority(AuthorityBuilder(host, tenant), c)
+        self.assertEqual(
+            a.authorization_endpoint,
+            'https://{}/{}/oauth2/v2.0/authorize'.format(host, tenant))
+        self.assertEqual(
+            a.token_endpoint,
+            'https://{}/{}/oauth2/v2.0/token'.format(host, tenant))
+        c.close()
+
     def test_wellknown_host_and_tenant(self):
         # Assert all well known authority hosts are using their own "common" tenant
         for host in WELL_KNOWN_AUTHORITY_HOSTS:
-            a = Authority(
-                'https://{}/common'.format(host), MinimalHttpClient())
-            self.assertEqual(
-                a.authorization_endpoint,
-                'https://%s/common/oauth2/v2.0/authorize' % host)
-            self.assertEqual(
-                a.token_endpoint, 'https://%s/common/oauth2/v2.0/token' % host)
+            self._test_given_host_and_tenant(host, "common")
+
+    def test_wellknown_host_and_tenant_using_new_authority_builder(self):
+        self._test_authority_builder(AZURE_PUBLIC, "consumers")
+        self._test_authority_builder(AZURE_CHINA, "organizations")
+        self._test_authority_builder(AZURE_US_GOVERNMENT, "common")
 
     @unittest.skip("As of Jan 2017, the server no longer returns V1 endpoint")
     def test_lessknown_host_will_return_a_set_of_v1_endpoints(self):


### PR DESCRIPTION
The new usage pattern is documented in [our doc staging site (please search the keyword "authority (str)") in this page](https://msal-python.readthedocs.io/en/docs-staging/).

You can also try the new syntax by pulling its feature branch:

    pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@cloud-instances

This is not a breaking change. The old school, low-level url string input is still supported.

This PR, once agreed upon and merged in, will resolve #221.
