### PR TITLE
Bubble up refresh exception when we cannot recover

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1207,7 +1207,9 @@ class ClientApplication(object):
             if (result and "error" not in result) or (not access_token_from_cache):
                 return result
         except:  # The exact HTTP exception is transportation-layer dependent
-            logger.exception("Refresh token failed")  # Potential AAD outage?
+            # Typically network error. Potential AAD outage?
+            if not access_token_from_cache:  # It means there is no fall back option
+                raise  # We choose to bubble up the exception
         return access_token_from_cache
 
     def _acquire_token_silent_by_finding_rt_belongs_to_me_or_my_family(


### PR DESCRIPTION
This will fix #431.

We won't have an easy way to test this. So, @jiasli please help the code review.

And, if the ConnectionError in Xing Zhuo's report is still observable, you can then pull in this feature branch and test it in rare real environment (by `pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@bubble-up-refresh-exception`).