### PR TITLE
Emit warning when common or organizations is used in acquire_token_for_client()

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1675,6 +1675,11 @@ class ConfidentialClientApplication(ClientApplication):  # server-side web app
             - an error response would contain "error" and usually "error_description".
         """
         # TBD: force_refresh behavior
+        if self.authority.tenant.lower() in ["common", "organizations"]:
+            warnings.warn(
+                "Using /common or /organizations authority "
+                "in acquire_token_for_client() is unreliable. "
+                "Please use a specific tenant instead.", DeprecationWarning)
         self._validate_ssh_cert_input_data(kwargs.get("data", {}))
         telemetry_context = self._build_telemetry_context(
             self.ACQUIRE_TOKEN_FOR_CLIENT_ID)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,5 +1,6 @@
 # Note: Since Aug 2019 we move all e2e tests into test_e2e.py,
 # so this test_application file contains only unit tests without dependency.
+import sys
 from msal.application import *
 from msal.application import _str2bytes
 import msal
@@ -601,4 +602,26 @@ class TestClientApplicationWillGroupAccounts(unittest.TestCase):
         self.assertIn("authority_type", account, "Backward compatibility")
         self.assertIn("local_account_id", account, "Backward compatibility")
         self.assertIn("realm", account, "Backward compatibility")
+
+
+@unittest.skipUnless(
+    sys.version_info[0] >= 3 and sys.version_info[1] >= 2,
+    "assertWarns() is only available in Python 3.2+")
+class TestClientCredentialGrant(unittest.TestCase):
+    def _test_certain_authority_should_emit_warnning(self, authority):
+        app = ConfidentialClientApplication(
+            "client_id", client_credential="secret", authority=authority)
+        def mock_post(url, headers=None, *args, **kwargs):
+            return MinimalResponse(
+                status_code=200, text=json.dumps({"access_token": "an AT"}))
+        with self.assertWarns(DeprecationWarning):
+            app.acquire_token_for_client(["scope"], post=mock_post)
+
+    def test_common_authority_should_emit_warnning(self):
+        self._test_certain_authority_should_emit_warnning(
+            authority="https://login.microsoftonline.com/common")
+
+    def test_organizations_authority_should_emit_warnning(self):
+        self._test_certain_authority_should_emit_warnning(
+            authority="https://login.microsoftonline.com/organizations")
 


### PR DESCRIPTION
This is the equivalent of MSAL .Net's https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/2888