### PR TITLE
Actionable exception from ADFS username password flow

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1417,12 +1417,18 @@ class ClientApplication(object):
             user_realm_result = self.authority.user_realm_discovery(
                 username, correlation_id=headers[msal.telemetry.CLIENT_REQUEST_ID])
             if user_realm_result.get("account_type") == "Federated":
-                response = _clean_up(self._acquire_token_by_username_password_federated(
-                    user_realm_result, username, password, scopes=scopes,
-                    data=data,
-                    headers=headers, **kwargs))
-                telemetry_context.update_telemetry(response)
-                return response
+                try:
+                    response = _clean_up(self._acquire_token_by_username_password_federated(
+                        user_realm_result, username, password, scopes=scopes,
+                        data=data,
+                        headers=headers, **kwargs))
+                except (ValueError, RuntimeError):
+                    raise RuntimeError(
+                        "ADFS is not configured properly. "
+                        "Consider use acquire_token_interactive() instead.")
+                else:
+                    telemetry_context.update_telemetry(response)
+                    return response
         response = _clean_up(self.client.obtain_token_by_username_password(
                 username, password, scope=scopes,
                 headers=headers,

--- a/msal/wstrust_request.py
+++ b/msal/wstrust_request.py
@@ -44,8 +44,8 @@ def send_request(
             soap_action = Mex.ACTION_2005
         elif '/trust/13/usernamemixed' in endpoint_address:
             soap_action = Mex.ACTION_13
-    assert soap_action in (Mex.ACTION_13, Mex.ACTION_2005), (  # A loose check here
-        "Unsupported soap action: %s" % soap_action)
+    if soap_action not in (Mex.ACTION_13, Mex.ACTION_2005):
+        raise ValueError("Unsupported soap action: %s" % soap_action)
     data = _build_rst(
         username, password, cloud_audience_urn, endpoint_address, soap_action)
     resp = http_client.post(endpoint_address, data=data, headers={


### PR DESCRIPTION
Inspired by https://github.com/Azure/azure-cli/issues/21068#issuecomment-1018752545 , this PR wraps most "expected" ADFS username password flow into one `RuntimeError` with actionable message.

That being said, this actionable message is meant for MSAL's app developer. If you are the app developer, you probably want to catch this `RuntimeError` and translate it into your own exception or error message, for example "... consider use 'az login' instead".  @jiasli 