### PR TITLE
Removes the middle-layer exception

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1417,18 +1417,12 @@ class ClientApplication(object):
             user_realm_result = self.authority.user_realm_discovery(
                 username, correlation_id=headers[msal.telemetry.CLIENT_REQUEST_ID])
             if user_realm_result.get("account_type") == "Federated":
-                try:
-                    response = _clean_up(self._acquire_token_by_username_password_federated(
-                        user_realm_result, username, password, scopes=scopes,
-                        data=data,
-                        headers=headers, **kwargs))
-                except (ValueError, RuntimeError):
-                    raise RuntimeError(
-                        "ADFS is not configured properly. "
-                        "Consider use acquire_token_interactive() instead.")
-                else:
-                    telemetry_context.update_telemetry(response)
-                    return response
+                response = _clean_up(self._acquire_token_by_username_password_federated(
+                    user_realm_result, username, password, scopes=scopes,
+                    data=data,
+                    headers=headers, **kwargs))
+                telemetry_context.update_telemetry(response)
+                return response
         response = _clean_up(self.client.obtain_token_by_username_password(
                 username, password, scope=scopes,
                 headers=headers,

--- a/msal/wstrust_request.py
+++ b/msal/wstrust_request.py
@@ -45,7 +45,8 @@ def send_request(
         elif '/trust/13/usernamemixed' in endpoint_address:
             soap_action = Mex.ACTION_13
     if soap_action not in (Mex.ACTION_13, Mex.ACTION_2005):
-        raise ValueError("Unsupported soap action: %s" % soap_action)
+        raise ValueError("Unsupported soap action: %s. "
+            "Contact your administrator to check your ADFS's MEX settings." % soap_action)
     data = _build_rst(
         username, password, cloud_audience_urn, endpoint_address, soap_action)
     resp = http_client.post(endpoint_address, data=data, headers={


### PR DESCRIPTION
@jiasli Azure CLI can then just catch all exceptions happened in `acquire_token_by_username_password()`, and then chain it with your CLIError:

```python
try:
    app.acquire_token_by_username_password(...)
except Exception as ex:
    raise CLIError('"az login -u ... -p ..." was unsuccessful. You may consider use "az login" instead.') from ex
```