### PR TITLE
Managed Identity for Azure VM, App Service, Service Fabric, etc.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -168,3 +168,23 @@ You may want to catch them to provide a better error message to your end users.
 
 .. autoclass:: msal.IdTokenError
 
+
+Managed Identity
+================
+MSAL supports
+`Managed Identity <https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview>`_.
+
+You can create one of these two kinds of managed identity configuration objects:
+
+.. autoclass:: msal.SystemAssignedManagedIdentity
+   :members:
+
+.. autoclass:: msal.UserAssignedManagedIdentity
+   :members:
+
+And then feed the configuration object into a :class:`ManagedIdentityClient` object.
+
+.. autoclass:: msal.ManagedIdentityClient
+   :members:
+
+   .. automethod:: __init__

--- a/msal/__init__.py
+++ b/msal/__init__.py
@@ -34,8 +34,14 @@ from .application import (
 from .oauth2cli.oidc import Prompt, IdTokenError
 from .token_cache import TokenCache, SerializableTokenCache
 from .auth_scheme import PopAuthScheme
+from .managed_identity import (
+    SystemAssignedManagedIdentity, UserAssignedManagedIdentity,
+    ManagedIdentityClient,
+    ManagedIdentityError,
+    )
 
 # Putting module-level exceptions into the package namespace, to make them
 # 1. officially part of the MSAL public API, and
 # 2. can still be caught by the user code even if we change the module structure.
 from .oauth2cli.oauth2 import BrowserInteractionTimeoutError
+

--- a/msal/__init__.py
+++ b/msal/__init__.py
@@ -38,6 +38,7 @@ from .managed_identity import (
     SystemAssignedManagedIdentity, UserAssignedManagedIdentity,
     ManagedIdentityClient,
     ManagedIdentityError,
+    ArcPlatformNotSupportedError,
     )
 
 # Putting module-level exceptions into the package namespace, to make them

--- a/msal/application.py
+++ b/msal/application.py
@@ -537,7 +537,11 @@ class ClientApplication(object):
             self.http_client.mount("https://", a)
         self.http_client = ThrottledHttpClient(
             self.http_client,
-            {} if http_cache is None else http_cache,  # Default to an in-memory dict
+            http_cache=http_cache,
+            default_throttle_time=60
+                # The default value 60 was recommended mainly for PCA at the end of
+                # https://identitydivision.visualstudio.com/devex/_git/AuthLibrariesApiReview?version=GBdev&path=%2FService%20protection%2FIntial%20set%20of%20protection%20measures.md&_a=preview
+                if isinstance(self, PublicClientApplication) else 5,
             )
 
         self.app_name = app_name

--- a/msal/managed_identity.py
+++ b/msal/managed_identity.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import socket
+import sys
 import time
 from urllib.parse import urlparse  # Python 3+
 from collections import UserDict  # Python 3+
@@ -507,6 +508,14 @@ def _obtain_token_on_service_fabric(
         raise
 
 
+_supported_arc_platforms_and_their_prefixes = {
+    "linux": "/var/opt/azcmagent/tokens",
+    "win32": os.path.expandvars(r"%ProgramData%\AzureConnectedMachineAgent\Tokens"),
+}
+
+class ArcPlatformNotSupportedError(ManagedIdentityError):
+    pass
+
 def _obtain_token_on_arc(http_client, endpoint, resource):
     # https://learn.microsoft.com/en-us/azure/azure-arc/servers/managed-identity-authentication
     logger.debug("Obtaining token via managed identity on Azure Arc")
@@ -525,7 +534,16 @@ def _obtain_token_on_arc(http_client, endpoint, resource):
             len(challenge) == 2 and challenge[0].lower() == "basic realm"):
         raise ManagedIdentityError(
             "Unrecognizable WWW-Authenticate header: {}".format(resp.headers))
-    with open(challenge[1]) as f:
+    if sys.platform not in _supported_arc_platforms_and_their_prefixes:
+        raise ArcPlatformNotSupportedError(
+            f"Platform {sys.platform} was undefined and unsupported")
+    filename = os.path.join(
+        # This algorithm is documented in an internal doc https://msazure.visualstudio.com/One/_wiki/wikis/One.wiki/233012/VM-Extension-Authoring-for-Arc?anchor=2.-obtaining-tokens
+        _supported_arc_platforms_and_their_prefixes[sys.platform],
+        os.path.splitext(os.path.basename(challenge[1]))[0] + ".key")
+    if os.stat(filename).st_size > 4096:  # Check size BEFORE loading its content
+        raise ManagedIdentityError("Local key file shall not be larger than 4KB")
+    with open(filename) as f:
         secret = f.read()
     response = http_client.get(
         endpoint,

--- a/msal/managed_identity.py
+++ b/msal/managed_identity.py
@@ -330,6 +330,15 @@ def _obtain_token(http_client, managed_identity, resource):
             managed_identity,
             resource,
         )
+    if "MSI_ENDPOINT" in os.environ and "MSI_SECRET" in os.environ:
+        # Back ported from https://github.com/Azure/azure-sdk-for-python/blob/azure-identity_1.15.0/sdk/identity/azure-identity/azure/identity/_credentials/azure_ml.py
+        return _obtain_token_on_machine_learning(
+            http_client,
+            os.environ["MSI_ENDPOINT"],
+            os.environ["MSI_SECRET"],
+            managed_identity,
+            resource,
+        )
     if "IDENTITY_ENDPOINT" in os.environ and "IMDS_ENDPOINT" in os.environ:
         if ManagedIdentity.is_user_assigned(managed_identity):
             raise ManagedIdentityError(  # Note: Azure Identity for Python raised exception too
@@ -346,6 +355,7 @@ def _obtain_token(http_client, managed_identity, resource):
 
 
 def _adjust_param(params, managed_identity):
+    # Modify the params dict in place
     id_name = ManagedIdentity._types_mapping.get(
         managed_identity.get(ManagedIdentity.ID_TYPE))
     if id_name:
@@ -417,6 +427,39 @@ def _obtain_token_on_app_service(
             "error": "invalid_scope",  # Empirically, wrong resource ends up with a vague statusCode=500
             "error_description": "{}, {}".format(
                 payload.get("statusCode"), payload.get("message")),
+            }
+    except json.decoder.JSONDecodeError:
+        logger.debug("IMDS emits unexpected payload: %s", resp.text)
+        raise
+
+def _obtain_token_on_machine_learning(
+    http_client, endpoint, secret, managed_identity, resource,
+):
+    # Could not find protocol docs from https://docs.microsoft.com/en-us/azure/machine-learning
+    # The following implementation is back ported from Azure Identity 1.15.0
+    logger.debug("Obtaining token via managed identity on Azure Machine Learning")
+    params = {"api-version": "2017-09-01", "resource": resource}
+    _adjust_param(params, managed_identity)
+    if params["api-version"] == "2017-09-01" and "client_id" in params:
+        # Workaround for a known bug in Azure ML 2017 API
+        params["clientid"] = params.pop("client_id")
+    resp = http_client.get(
+        endpoint,
+        params=params,
+        headers={"secret": secret},
+        )
+    try:
+        payload = json.loads(resp.text)
+        if payload.get("access_token") and payload.get("expires_on"):
+            return {  # Normalizing the payload into OAuth2 format
+                "access_token": payload["access_token"],
+                "expires_in": int(payload["expires_on"]) - int(time.time()),
+                "resource": payload.get("resource"),
+                "token_type": payload.get("token_type", "Bearer"),
+                }
+        return {
+            "error": "invalid_scope",  # TODO: To be tested
+            "error_description": "{}".format(payload),
             }
     except json.decoder.JSONDecodeError:
         logger.debug("IMDS emits unexpected payload: %s", resp.text)

--- a/msal/managed_identity.py
+++ b/msal/managed_identity.py
@@ -1,0 +1,477 @@
+# Copyright (c) Microsoft Corporation.
+# All rights reserved.
+#
+# This code is licensed under the MIT License.
+import json
+import logging
+import os
+import socket
+import time
+from urllib.parse import urlparse  # Python 3+
+from collections import UserDict  # Python 3+
+from typing import Union  # Needed in Python 3.7 & 3.8
+from .token_cache import TokenCache
+from .throttled_http_client import ThrottledHttpClient
+
+
+logger = logging.getLogger(__name__)
+
+
+class ManagedIdentityError(ValueError):
+    pass
+
+
+class ManagedIdentity(UserDict):
+    """Feed an instance of this class to :class:`msal.ManagedIdentityClient`
+    to acquire token for the specified managed identity.
+    """
+    # The key names used in config dict
+    ID_TYPE = "ManagedIdentityIdType"  # Contains keyword ManagedIdentity so its json equivalent will be more readable
+    ID = "Id"
+
+    # Valid values for key ID_TYPE
+    CLIENT_ID = "ClientId"
+    RESOURCE_ID = "ResourceId"
+    OBJECT_ID = "ObjectId"
+    SYSTEM_ASSIGNED = "SystemAssigned"
+
+    _types_mapping = {  # Maps type name in configuration to type name on wire
+        CLIENT_ID: "client_id",
+        RESOURCE_ID: "mi_res_id",
+        OBJECT_ID: "object_id",
+    }
+
+    @classmethod
+    def is_managed_identity(cls, unknown):
+        return isinstance(unknown, ManagedIdentity) or (
+            isinstance(unknown, dict) and cls.ID_TYPE in unknown)
+
+    @classmethod
+    def is_system_assigned(cls, unknown):
+        return isinstance(unknown, SystemAssignedManagedIdentity) or (
+            isinstance(unknown, dict)
+            and unknown.get(cls.ID_TYPE) == cls.SYSTEM_ASSIGNED)
+
+    @classmethod
+    def is_user_assigned(cls, unknown):
+        return isinstance(unknown, UserAssignedManagedIdentity) or (
+            isinstance(unknown, dict)
+            and unknown.get(cls.ID_TYPE) in cls._types_mapping
+            and unknown.get(cls.ID))
+
+    def __init__(self, identifier=None, id_type=None):
+        # Undocumented. Use subclasses instead.
+        super(ManagedIdentity, self).__init__({
+            self.ID_TYPE: id_type,
+            self.ID: identifier,
+        })
+
+
+class SystemAssignedManagedIdentity(ManagedIdentity):
+    """Represent a system-assigned managed identity.
+
+    It is equivalent to a Python dict of::
+
+        {"ManagedIdentityIdType": "SystemAssigned", "Id": None}
+
+    or a JSON blob of::
+
+        {"ManagedIdentityIdType": "SystemAssigned", "Id": null}
+    """
+    def __init__(self):
+        super(SystemAssignedManagedIdentity, self).__init__(id_type=self.SYSTEM_ASSIGNED)
+
+
+class UserAssignedManagedIdentity(ManagedIdentity):
+    """Represent a user-assigned managed identity.
+
+    Depends on the id you provided, the outcome is equivalent to one of the below::
+
+        {"ManagedIdentityIdType": "ClientId", "Id": "foo"}
+        {"ManagedIdentityIdType": "ResourceId", "Id": "foo"}
+        {"ManagedIdentityIdType": "ObjectId", "Id": "foo"}
+    """
+    def __init__(self, *, client_id=None, resource_id=None, object_id=None):
+        if client_id and not resource_id and not object_id:
+            super(UserAssignedManagedIdentity, self).__init__(
+                id_type=self.CLIENT_ID, identifier=client_id)
+        elif not client_id and resource_id and not object_id:
+            super(UserAssignedManagedIdentity, self).__init__(
+                id_type=self.RESOURCE_ID, identifier=resource_id)
+        elif not client_id and not resource_id and object_id:
+            super(UserAssignedManagedIdentity, self).__init__(
+                id_type=self.OBJECT_ID, identifier=object_id)
+        else:
+            raise ManagedIdentityError(
+                "You shall specify one of the three parameters: "
+                "client_id, resource_id, object_id")
+
+
+class ManagedIdentityClient(object):
+    """This API encapsulates multiple managed identity back-ends:
+    VM, App Service, Azure Automation (Runbooks), Azure Function, Service Fabric,
+    and Azure Arc.
+
+    It also provides token cache support.
+
+    .. note::
+
+        Cloud Shell support is NOT implemented in this class.
+        Since MSAL Python 1.18 in May 2022, it has been implemented in
+        :func:`PublicClientApplication.acquire_token_interactive` via calling pattern
+        ``PublicClientApplication(...).acquire_token_interactive(scopes=[...], prompt="none")``.
+        That is appropriate, because Cloud Shell yields a token with
+        delegated permissions for the end user who has signed in to the Azure Portal
+        (like what a ``PublicClientApplication`` does),
+        not a token with application permissions for an app.
+    """
+    _instance, _tenant = socket.getfqdn(), "managed_identity"  # Placeholders
+
+    def __init__(
+        self,
+        managed_identity: Union[
+            dict,
+            ManagedIdentity,  # Could use Type[ManagedIdentity] but it is deprecatred in Python 3.9+
+            SystemAssignedManagedIdentity,
+            UserAssignedManagedIdentity,
+            ],
+        *,
+        http_client,
+        token_cache=None,
+    ):
+        """Create a managed identity client.
+
+        :param managed_identity:
+            It accepts an instance of :class:`SystemAssignedManagedIdentity`
+            or :class:`UserAssignedManagedIdentity`.
+            They are equivalent to a dict with a certain shape,
+            which may be loaded from a JSON configuration file or an env var.
+
+        :param http_client:
+            An http client object. For example, you can use ``requests.Session()``,
+            optionally with exponential backoff behavior demonstrated in this recipe::
+
+                import msal, requests
+                from requests.adapters import HTTPAdapter, Retry
+                s = requests.Session()
+                retries = Retry(total=3, backoff_factor=0.1, status_forcelist=[
+                    429, 500, 501, 502, 503, 504])
+                s.mount('https://', HTTPAdapter(max_retries=retries))
+                managed_identity = ...
+                client = msal.ManagedIdentityClient(managed_identity, http_client=s)
+
+        :param token_cache:
+            Optional. It accepts a :class:`msal.TokenCache` instance to store tokens.
+            It will use an in-memory token cache by default.
+
+        Recipe 1: Hard code a managed identity for your app::
+
+            import msal, requests
+            client = msal.ManagedIdentityClient(
+                msal.UserAssignedManagedIdentity(client_id="foo"),
+                http_client=requests.Session(),
+                )
+            token = client.acquire_token_for_client("resource")
+
+        Recipe 2: Write once, run everywhere.
+        If you use different managed identity on different deployment,
+        you may use an environment variable (such as MY_MANAGED_IDENTITY_CONFIG)
+        to store a json blob like
+        ``{"ManagedIdentityIdType": "ClientId", "Id": "foo"}`` or
+        ``{"ManagedIdentityIdType": "SystemAssignedManagedIdentity", "Id": null})``.
+        The following app can load managed identity configuration dynamically::
+
+            import json, os, msal, requests
+            config = os.getenv("MY_MANAGED_IDENTITY_CONFIG")
+            assert config, "An ENV VAR with value should exist"
+            client = msal.ManagedIdentityClient(
+                json.loads(config),
+                http_client=requests.Session(),
+                )
+            token = client.acquire_token_for_client("resource")
+        """
+        self._managed_identity = managed_identity
+        if isinstance(http_client, ThrottledHttpClient):
+            raise ValueError(
+                # It is a precaution to reject application.py's throttled http_client,
+                # whose cache life on HTTP GET 200 is too long for Managed Identity.
+                "This class does not currently accept a ThrottledHttpClient.")
+        self._http_client = http_client
+        self._token_cache = token_cache or TokenCache()
+
+    def acquire_token_for_client(self, *, resource):  # We may support scope in the future
+        """Acquire token for the managed identity.
+
+        The result will be automatically cached.
+        Subsequent calls will automatically search from cache first.
+
+        .. note::
+
+            Known issue: When an Azure VM has only one user-assigned managed identity,
+            and your app specifies to use system-assigned managed identity,
+            Azure VM may still return a token for your user-assigned identity.
+
+            This is a service-side behavior that cannot be changed by this library.
+            `Azure VM docs <https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http>`_
+        """
+        access_token_from_cache = None
+        client_id_in_cache = self._managed_identity.get(
+            ManagedIdentity.ID, "SYSTEM_ASSIGNED_MANAGED_IDENTITY")
+        if True:  # Does not offer an "if not force_refresh" option, because
+                  # there would be built-in token cache in the service side anyway
+            matches = self._token_cache.find(
+                self._token_cache.CredentialType.ACCESS_TOKEN,
+                target=[resource],
+                query=dict(
+                    client_id=client_id_in_cache,
+                    environment=self._instance,
+                    realm=self._tenant,
+                    home_account_id=None,
+                ),
+            )
+            now = time.time()
+            for entry in matches:
+                expires_in = int(entry["expires_on"]) - now
+                if expires_in < 5*60:  # Then consider it expired
+                    continue  # Removal is not necessary, it will be overwritten
+                logger.debug("Cache hit an AT")
+                access_token_from_cache = {  # Mimic a real response
+                    "access_token": entry["secret"],
+                    "token_type": entry.get("token_type", "Bearer"),
+                    "expires_in": int(expires_in),  # OAuth2 specs defines it as int
+                }
+                if "refresh_on" in entry and int(entry["refresh_on"]) < now:  # aging
+                    break  # With a fallback in hand, we break here to go refresh
+                return access_token_from_cache  # It is still good as new
+        try:
+            result = _obtain_token(self._http_client, self._managed_identity, resource)
+            if "access_token" in result:
+                expires_in = result.get("expires_in", 3600)
+                if "refresh_in" not in result and expires_in >= 7200:
+                    result["refresh_in"] = int(expires_in / 2)
+                self._token_cache.add(dict(
+                    client_id=client_id_in_cache,
+                    scope=[resource],
+                    token_endpoint="https://{}/{}".format(self._instance, self._tenant),
+                    response=result,
+                    params={},
+                    data={},
+                ))
+            if (result and "error" not in result) or (not access_token_from_cache):
+                return result
+        except:  # The exact HTTP exception is transportation-layer dependent
+            # Typically network error. Potential AAD outage?
+            if not access_token_from_cache:  # It means there is no fall back option
+                raise  # We choose to bubble up the exception
+        return access_token_from_cache
+
+
+def _scope_to_resource(scope):  # This is an experimental reasonable-effort approach
+    u = urlparse(scope)
+    if u.scheme:
+        return "{}://{}".format(u.scheme, u.netloc)
+    return scope  # There is no much else we can do here
+
+
+def _obtain_token(http_client, managed_identity, resource):
+    # A unified low-level API that talks to different Managed Identity
+    if ("IDENTITY_ENDPOINT" in os.environ and "IDENTITY_HEADER" in os.environ
+            and "IDENTITY_SERVER_THUMBPRINT" in os.environ
+    ):
+        if managed_identity:
+            logger.debug(
+                "Ignoring managed_identity parameter. "
+                "Managed Identity in Service Fabric is configured in the cluster, "
+                "not during runtime. See also "
+                "https://learn.microsoft.com/en-us/azure/service-fabric/configure-existing-cluster-enable-managed-identity-token-service")
+        return _obtain_token_on_service_fabric(
+            http_client,
+            os.environ["IDENTITY_ENDPOINT"],
+            os.environ["IDENTITY_HEADER"],
+            os.environ["IDENTITY_SERVER_THUMBPRINT"],
+            resource,
+        )
+    if "IDENTITY_ENDPOINT" in os.environ and "IDENTITY_HEADER" in os.environ:
+        return _obtain_token_on_app_service(
+            http_client,
+            os.environ["IDENTITY_ENDPOINT"],
+            os.environ["IDENTITY_HEADER"],
+            managed_identity,
+            resource,
+        )
+    if "IDENTITY_ENDPOINT" in os.environ and "IMDS_ENDPOINT" in os.environ:
+        if ManagedIdentity.is_user_assigned(managed_identity):
+            raise ManagedIdentityError(  # Note: Azure Identity for Python raised exception too
+                "Invalid managed_identity parameter. "
+                "Azure Arc supports only system-assigned managed identity, "
+                "See also "
+                "https://learn.microsoft.com/en-us/azure/service-fabric/configure-existing-cluster-enable-managed-identity-token-service")
+        return _obtain_token_on_arc(
+            http_client,
+            os.environ["IDENTITY_ENDPOINT"],
+            resource,
+        )
+    return _obtain_token_on_azure_vm(http_client, managed_identity, resource)
+
+
+def _adjust_param(params, managed_identity):
+    id_name = ManagedIdentity._types_mapping.get(
+        managed_identity.get(ManagedIdentity.ID_TYPE))
+    if id_name:
+        params[id_name] = managed_identity[ManagedIdentity.ID]
+
+def _obtain_token_on_azure_vm(http_client, managed_identity, resource):
+    # Based on https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
+    logger.debug("Obtaining token via managed identity on Azure VM")
+    params = {
+        "api-version": "2018-02-01",
+        "resource": resource,
+        }
+    _adjust_param(params, managed_identity)
+    resp = http_client.get(
+        "http://169.254.169.254/metadata/identity/oauth2/token",
+        params=params,
+        headers={"Metadata": "true"},
+        )
+    try:
+        payload = json.loads(resp.text)
+        if payload.get("access_token") and payload.get("expires_in"):
+            return {  # Normalizing the payload into OAuth2 format
+                "access_token": payload["access_token"],
+                "expires_in": int(payload["expires_in"]),
+                "resource": payload.get("resource"),
+                "token_type": payload.get("token_type", "Bearer"),
+                }
+        return payload  # Typically an error, but it is undefined in the doc above
+    except json.decoder.JSONDecodeError:
+        logger.debug("IMDS emits unexpected payload: %s", resp.text)
+        raise
+
+def _obtain_token_on_app_service(
+    http_client, endpoint, identity_header, managed_identity, resource,
+):
+    """Obtains token for
+    `App Service <https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp#rest-endpoint-reference>`_,
+    Azure Functions, and Azure Automation.
+    """
+    # Prerequisite: Create your app service https://docs.microsoft.com/en-us/azure/app-service/quickstart-python
+    # Assign it a managed identity https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Chttp
+    # SSH into your container for testing https://docs.microsoft.com/en-us/azure/app-service/configure-linux-open-ssh-session
+    logger.debug("Obtaining token via managed identity on Azure App Service")
+    params = {
+        "api-version": "2019-08-01",
+        "resource": resource,
+        }
+    _adjust_param(params, managed_identity)
+    resp = http_client.get(
+        endpoint,
+        params=params,
+        headers={
+            "X-IDENTITY-HEADER": identity_header,
+            "Metadata": "true",  # Unnecessary yet harmless for App Service,
+            # It will be needed by Azure Automation
+            # https://docs.microsoft.com/en-us/azure/automation/enable-managed-identity-for-automation#get-access-token-for-system-assigned-managed-identity-using-http-get
+            },
+        )
+    try:
+        payload = json.loads(resp.text)
+        if payload.get("access_token") and payload.get("expires_on"):
+            return {  # Normalizing the payload into OAuth2 format
+                "access_token": payload["access_token"],
+                "expires_in": int(payload["expires_on"]) - int(time.time()),
+                "resource": payload.get("resource"),
+                "token_type": payload.get("token_type", "Bearer"),
+                }
+        return {
+            "error": "invalid_scope",  # Empirically, wrong resource ends up with a vague statusCode=500
+            "error_description": "{}, {}".format(
+                payload.get("statusCode"), payload.get("message")),
+            }
+    except json.decoder.JSONDecodeError:
+        logger.debug("IMDS emits unexpected payload: %s", resp.text)
+        raise
+
+
+def _obtain_token_on_service_fabric(
+    http_client, endpoint, identity_header, server_thumbprint, resource,
+):
+    """Obtains token for
+    `Service Fabric <https://learn.microsoft.com/en-us/azure/service-fabric/>`_
+    """
+    # Deployment https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-get-started-containers-linux
+    # See also https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/tests/managed-identity-live/service-fabric/service_fabric.md
+    # Protocol https://learn.microsoft.com/en-us/azure/service-fabric/how-to-managed-identity-service-fabric-app-code#acquiring-an-access-token-using-rest-api
+    logger.debug("Obtaining token via managed identity on Azure Service Fabric")
+    resp = http_client.get(
+        endpoint,
+        params={"api-version": "2019-07-01-preview", "resource": resource},
+        headers={"Secret": identity_header},
+        )
+    try:
+        payload = json.loads(resp.text)
+        if payload.get("access_token") and payload.get("expires_on"):
+            return {  # Normalizing the payload into OAuth2 format
+                "access_token": payload["access_token"],
+                "expires_in": int(  # Despite the example in docs shows an integer,
+                    payload["expires_on"]  # Azure SDK team's test obtained a string.
+                    ) - int(time.time()),
+                "resource": payload.get("resource"),
+                "token_type": payload["token_type"],
+                }
+        error = payload.get("error", {})  # https://learn.microsoft.com/en-us/azure/service-fabric/how-to-managed-identity-service-fabric-app-code#error-handling
+        error_mapping = {  # Map Service Fabric errors into OAuth2 errors  https://www.rfc-editor.org/rfc/rfc6749#section-5.2
+            "SecretHeaderNotFound": "unauthorized_client",
+            "ManagedIdentityNotFound": "invalid_client",
+            "ArgumentNullOrEmpty": "invalid_scope",
+            }
+        return {
+            "error": error_mapping.get(payload["error"]["code"], "invalid_request"),
+            "error_description": resp.text,
+            }
+    except json.decoder.JSONDecodeError:
+        logger.debug("IMDS emits unexpected payload: %s", resp.text)
+        raise
+
+
+def _obtain_token_on_arc(http_client, endpoint, resource):
+    # https://learn.microsoft.com/en-us/azure/azure-arc/servers/managed-identity-authentication
+    logger.debug("Obtaining token via managed identity on Azure Arc")
+    resp = http_client.get(
+        endpoint,
+        params={"api-version": "2020-06-01", "resource": resource},
+        headers={"Metadata": "true"},
+        )
+    www_auth = "www-authenticate"  # Header in lower case
+    challenge = {
+        # Normalized to lowercase, because header names are case-insensitive
+        # https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+        k.lower(): v for k, v in resp.headers.items() if k.lower() == www_auth
+        }.get(www_auth, "").split("=")  # Output will be ["Basic realm", "content"]
+    if not (  # https://datatracker.ietf.org/doc/html/rfc7617#section-2
+            len(challenge) == 2 and challenge[0].lower() == "basic realm"):
+        raise ManagedIdentityError(
+            "Unrecognizable WWW-Authenticate header: {}".format(resp.headers))
+    with open(challenge[1]) as f:
+        secret = f.read()
+    response = http_client.get(
+        endpoint,
+        params={"api-version": "2020-06-01", "resource": resource},
+        headers={"Metadata": "true", "Authorization": "Basic {}".format(secret)},
+        )
+    try:
+        payload = json.loads(response.text)
+        if payload.get("access_token") and payload.get("expires_in"):
+            # Example: https://learn.microsoft.com/en-us/azure/azure-arc/servers/media/managed-identity-authentication/bash-token-output-example.png
+            return {
+                "access_token": payload["access_token"],
+                "expires_in": int(payload["expires_in"]),
+                "token_type": payload.get("token_type", "Bearer"),
+                "resource": payload.get("resource"),
+                }
+    except json.decoder.JSONDecodeError:
+        pass
+    return {
+        "error": "invalid_request",
+        "error_description": response.text,
+        }
+

--- a/sample/.env.sample.managed_identity
+++ b/sample/.env.sample.managed_identity
@@ -1,0 +1,17 @@
+# This sample can be configured to work with Microsoft Entra ID's Managed Identity.
+#
+# A user-assigned managed identity can be represented as a JSON blob.
+# Check MSAL Python's API Reference for its syntax.
+# https://msal-python.readthedocs.io/en/latest/#managed-identity
+#
+# Example value when using a user-assigned managed identity:
+#       {"ManagedIdentityIdType": "ClientId", "Id": "your_managed_identity_id"}
+# Leave it empty or absent if you are using a system-assigned managed identity.
+MANAGED_IDENTITY=<managed_identity>
+
+# Managed Identity works with resource, not scopes.
+RESOURCE=<your resource>
+
+# Required if the sample app wants to call an API.
+#ENDPOINT=https://graph.microsoft.com/v1.0/me
+

--- a/sample/managed_identity_sample.py
+++ b/sample/managed_identity_sample.py
@@ -1,0 +1,77 @@
+"""
+This sample demonstrates a daemon application that acquires a token using a
+managed identity and then calls a web API with the token.
+
+This sample loads its configuration from a .env file.
+
+To make this sample work, you need to choose this template:
+
+    .env.sample.managed_identity
+
+Copy the chosen template to a new file named .env, and fill in the values.
+
+You can then run this sample:
+
+    python name_of_this_script.py
+"""
+import json
+import logging
+import os
+import time
+
+from dotenv import load_dotenv  # Need "pip install python-dotenv"
+import msal
+import requests
+
+
+# Optional logging
+# logging.basicConfig(level=logging.DEBUG)  # Enable DEBUG log for entire script
+# logging.getLogger("msal").setLevel(logging.INFO)  # Optionally disable MSAL DEBUG logs
+
+load_dotenv()  # We use this to load configuration from a .env file
+
+# If for whatever reason you plan to recreate same ClientApplication periodically,
+# you shall create one global token cache and reuse it by each ClientApplication
+global_token_cache = msal.TokenCache()  # The TokenCache() is in-memory.
+    # See more options in https://msal-python.readthedocs.io/en/latest/#tokencache
+
+# Create a managed identity instance based on the environment variable value
+if os.getenv('MANAGED_IDENTITY'):
+    managed_identity = json.loads(os.getenv('MANAGED_IDENTITY'))
+else:
+    managed_identity = msal.SystemAssignedManagedIdentity()
+
+# Create a preferably long-lived app instance, to avoid the overhead of app creation
+global_app = msal.ManagedIdentityClient(
+    managed_identity,
+    http_client=requests.Session(),
+    token_cache=global_token_cache,  # Let this app (re)use an existing token cache.
+        # If absent, ClientApplication will create its own empty token cache
+    )
+resource = os.getenv("RESOURCE")
+
+
+def acquire_and_use_token():
+    # ManagedIdentityClient.acquire_token_for_client(...) will automatically look up
+    # a token from cache, and fall back to acquire a fresh token when needed.
+    result = global_app.acquire_token_for_client(resource=resource)
+
+    if "access_token" in result:
+        if os.getenv('ENDPOINT'):
+            # Calling a web API using the access token
+            api_result = requests.get(
+                os.getenv('ENDPOINT'),
+                headers={'Authorization': 'Bearer ' + result['access_token']},
+                ).json()  # Assuming the response is JSON
+            print("Web API call result", json.dumps(api_result, indent=2))
+        else:
+            print("Token acquisition result", json.dumps(result, indent=2))
+    else:
+        print("Token acquisition failed", result)  # Examine result["error_description"] etc. to diagnose error
+
+
+while True:  # Here we mimic a long-lived daemon
+    acquire_and_use_token()
+    print("Press Ctrl-C to stop.")
+    time.sleep(5)  # Let's say your app would run a workload every X minutes
+

--- a/tests/test_mi.py
+++ b/tests/test_mi.py
@@ -1,0 +1,198 @@
+import json
+import os
+import sys
+import time
+import unittest
+try:
+    from unittest.mock import patch, ANY, mock_open
+except:
+    from mock import patch, ANY, mock_open
+import requests
+
+from tests.http_client import MinimalResponse
+from msal import (
+    SystemAssignedManagedIdentity, UserAssignedManagedIdentity,
+    ManagedIdentityClient,
+    ManagedIdentityError,
+)
+
+
+class ManagedIdentityTestCase(unittest.TestCase):
+    def test_helper_class_should_be_interchangable_with_dict_which_could_be_loaded_from_file_or_env_var(self):
+        self.assertEqual(
+            UserAssignedManagedIdentity(client_id="foo"),
+            {"ManagedIdentityIdType": "ClientId", "Id": "foo"})
+        self.assertEqual(
+            UserAssignedManagedIdentity(resource_id="foo"),
+            {"ManagedIdentityIdType": "ResourceId", "Id": "foo"})
+        self.assertEqual(
+            UserAssignedManagedIdentity(object_id="foo"),
+            {"ManagedIdentityIdType": "ObjectId", "Id": "foo"})
+        with self.assertRaises(ManagedIdentityError):
+            UserAssignedManagedIdentity()
+        with self.assertRaises(ManagedIdentityError):
+            UserAssignedManagedIdentity(client_id="foo", resource_id="bar")
+        self.assertEqual(
+            SystemAssignedManagedIdentity(),
+            {"ManagedIdentityIdType": "SystemAssigned", "Id": None})
+
+
+class ClientTestCase(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.app = ManagedIdentityClient(
+            {   # Here we test it with the raw dict form, to test that
+                # the client has no hard dependency on ManagedIdentity object
+                "ManagedIdentityIdType": "SystemAssigned", "Id": None,
+            },
+            http_client=requests.Session(),
+            )
+
+    def _test_token_cache(self, app):
+        cache = app._token_cache._cache
+        self.assertEqual(1, len(cache.get("AccessToken", [])), "Should have 1 AT")
+        at = list(cache["AccessToken"].values())[0]
+        self.assertEqual(
+            app._managed_identity.get("Id", "SYSTEM_ASSIGNED_MANAGED_IDENTITY"),
+            at["client_id"],
+            "Should have expected client_id")
+        self.assertEqual("managed_identity", at["realm"], "Should have expected realm")
+
+    def _test_happy_path(self, app, mocked_http):
+        result = app.acquire_token_for_client(resource="R")
+        mocked_http.assert_called()
+        self.assertEqual({
+            "access_token": "AT",
+            "expires_in": 1234,
+            "resource": "R",
+            "token_type": "Bearer",
+        }, result, "Should obtain a token response")
+        self.assertEqual(
+            result["access_token"],
+            app.acquire_token_for_client(resource="R").get("access_token"),
+            "Should hit the same token from cache")
+        self._test_token_cache(app)
+
+
+class VmTestCase(ClientTestCase):
+
+    def test_happy_path(self):
+        with patch.object(self.app._http_client, "get", return_value=MinimalResponse(
+            status_code=200,
+            text='{"access_token": "AT", "expires_in": "1234", "resource": "R"}',
+        )) as mocked_method:
+            self._test_happy_path(self.app, mocked_method)
+
+    def test_vm_error_should_be_returned_as_is(self):
+        raw_error = '{"raw": "error format is undefined"}'
+        with patch.object(self.app._http_client, "get", return_value=MinimalResponse(
+            status_code=400,
+            text=raw_error,
+        )) as mocked_method:
+            self.assertEqual(
+                json.loads(raw_error), self.app.acquire_token_for_client(resource="R"))
+            self.assertEqual({}, self.app._token_cache._cache)
+
+
+@patch.dict(os.environ, {"IDENTITY_ENDPOINT": "http://localhost", "IDENTITY_HEADER": "foo"})
+class AppServiceTestCase(ClientTestCase):
+
+    def test_happy_path(self):
+        with patch.object(self.app._http_client, "get", return_value=MinimalResponse(
+            status_code=200,
+            text='{"access_token": "AT", "expires_on": "%s", "resource": "R"}' % (
+                int(time.time()) + 1234),
+        )) as mocked_method:
+            self._test_happy_path(self.app, mocked_method)
+
+    def test_app_service_error_should_be_normalized(self):
+        raw_error = '{"statusCode": 500, "message": "error content is undefined"}'
+        with patch.object(self.app._http_client, "get", return_value=MinimalResponse(
+            status_code=500,
+            text=raw_error,
+        )) as mocked_method:
+            self.assertEqual({
+                "error": "invalid_scope",
+                "error_description": "500, error content is undefined",
+            }, self.app.acquire_token_for_client(resource="R"))
+            self.assertEqual({}, self.app._token_cache._cache)
+
+
+@patch.dict(os.environ, {
+    "IDENTITY_ENDPOINT": "http://localhost",
+    "IDENTITY_HEADER": "foo",
+    "IDENTITY_SERVER_THUMBPRINT": "bar",
+})
+class ServiceFabricTestCase(ClientTestCase):
+
+    def _test_happy_path(self, app):
+        with patch.object(app._http_client, "get", return_value=MinimalResponse(
+            status_code=200,
+            text='{"access_token": "AT", "expires_on": %s, "resource": "R", "token_type": "Bearer"}' % (
+                int(time.time()) + 1234),
+        )) as mocked_method:
+            super(ServiceFabricTestCase, self)._test_happy_path(app, mocked_method)
+
+    def test_happy_path(self):
+        self._test_happy_path(self.app)
+
+    def test_unified_api_service_should_ignore_unnecessary_client_id(self):
+        self._test_happy_path(ManagedIdentityClient(
+            {"ManagedIdentityIdType": "ClientId", "Id": "foo"},
+            http_client=requests.Session(),
+            ))
+
+    def test_sf_error_should_be_normalized(self):
+        raw_error = '''
+{"error": {
+    "correlationId": "foo",
+    "code": "SecretHeaderNotFound",
+    "message": "Secret is not found in the request headers."
+}}'''  # https://learn.microsoft.com/en-us/azure/service-fabric/how-to-managed-identity-service-fabric-app-code#error-handling
+        with patch.object(self.app._http_client, "get", return_value=MinimalResponse(
+            status_code=404,
+            text=raw_error,
+        )) as mocked_method:
+            self.assertEqual({
+                "error": "unauthorized_client",
+                "error_description": raw_error,
+            }, self.app.acquire_token_for_client(resource="R"))
+            self.assertEqual({}, self.app._token_cache._cache)
+
+
+@patch.dict(os.environ, {
+    "IDENTITY_ENDPOINT": "http://localhost/token",
+    "IMDS_ENDPOINT": "http://localhost",
+})
+@patch(
+    "builtins.open" if sys.version_info.major >= 3 else "__builtin__.open",
+    new=mock_open(read_data="secret"),  # `new` requires no extra argument on the decorated function.
+        #  https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch
+)
+class ArcTestCase(ClientTestCase):
+    challenge = MinimalResponse(status_code=401, text="", headers={
+        "WWW-Authenticate": "Basic realm=/tmp/foo",
+        })
+
+    def test_happy_path(self):
+        with patch.object(self.app._http_client, "get", side_effect=[
+            self.challenge,
+            MinimalResponse(
+                status_code=200,
+                text='{"access_token": "AT", "expires_in": "1234", "resource": "R"}',
+                ),
+        ]) as mocked_method:
+            super(ArcTestCase, self)._test_happy_path(self.app, mocked_method)
+
+    def test_arc_error_should_be_normalized(self):
+        with patch.object(self.app._http_client, "get", side_effect=[
+            self.challenge,
+            MinimalResponse(status_code=400, text="undefined"),
+        ]) as mocked_method:
+            self.assertEqual({
+                "error": "invalid_request",
+                "error_description": "undefined",
+            }, self.app.acquire_token_for_client(resource="R"))
+            self.assertEqual({}, self.app._token_cache._cache)
+

--- a/tests/test_throttled_http_client.py
+++ b/tests/test_throttled_http_client.py
@@ -40,11 +40,10 @@ class CloseMethodCalled(Exception):
 class TestHttpDecoration(unittest.TestCase):
 
     def test_throttled_http_client_should_not_alter_original_http_client(self):
-        http_cache = {}
         original_http_client = DummyHttpClient()
         original_get = original_http_client.get
         original_post = original_http_client.post
-        throttled_http_client = ThrottledHttpClient(original_http_client, http_cache)
+        throttled_http_client = ThrottledHttpClient(original_http_client)
         goal = """The implementation should wrap original http_client
             and keep it intact, instead of monkey-patching it"""
         self.assertNotEqual(throttled_http_client, original_http_client, goal)
@@ -54,7 +53,7 @@ class TestHttpDecoration(unittest.TestCase):
     def _test_RetryAfter_N_seconds_should_keep_entry_for_N_seconds(
             self, http_client, retry_after):
         http_cache = {}
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client, http_cache=http_cache)
         resp1 = http_client.post("https://example.com")  # We implemented POST only
         resp2 = http_client.post("https://example.com")  # We implemented POST only
         logger.debug(http_cache)
@@ -90,7 +89,7 @@ class TestHttpDecoration(unittest.TestCase):
         http_cache = {}
         http_client = DummyHttpClient(
             status_code=429, response_headers={"Retry-After": 2})
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client, http_cache=http_cache)
         resp1 = http_client.post("https://example.com", data={
             "scope": "one", "claims": "bar", "grant_type": "authorization_code"})
         resp2 = http_client.post("https://example.com", data={
@@ -102,7 +101,7 @@ class TestHttpDecoration(unittest.TestCase):
         http_cache = {}
         http_client = DummyHttpClient(
             status_code=429, response_headers={"Retry-After": 2})
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client, http_cache=http_cache)
         resp1 = http_client.post("https://example.com", data={"scope": "one"})
         resp2 = http_client.post("https://example.com", data={"scope": "two"})
         logger.debug(http_cache)
@@ -112,7 +111,7 @@ class TestHttpDecoration(unittest.TestCase):
         http_cache = {}
         http_client = DummyHttpClient(
             status_code=400)  # It covers invalid_grant and interaction_required
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client, http_cache=http_cache)
         resp1 = http_client.post("https://example.com", data={"claims": "foo"})
         logger.debug(http_cache)
         resp1_again = http_client.post("https://example.com", data={"claims": "foo"})
@@ -146,7 +145,7 @@ class TestHttpDecoration(unittest.TestCase):
         http_cache = {}
         http_client = DummyHttpClient(
             status_code=200)  # It covers UserRealm discovery and OIDC discovery
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client, http_cache=http_cache)
         resp1 = http_client.get("https://example.com?foo=bar")
         resp2 = http_client.get("https://example.com?foo=bar")
         logger.debug(http_cache)
@@ -156,7 +155,7 @@ class TestHttpDecoration(unittest.TestCase):
         DEVICE_AUTH_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
         http_cache = {}
         http_client = DummyHttpClient(status_code=400)
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client, http_cache=http_cache)
         resp1 = http_client.post(
             "https://example.com", data={"grant_type": DEVICE_AUTH_GRANT})
         resp2 = http_client.post(
@@ -165,9 +164,8 @@ class TestHttpDecoration(unittest.TestCase):
         self.assertNotEqual(resp1.text, resp2.text, "Should return a new response")
 
     def test_throttled_http_client_should_provide_close(self):
-        http_cache = {}
         http_client = DummyHttpClient(status_code=200)
-        http_client = ThrottledHttpClient(http_client, http_cache)
+        http_client = ThrottledHttpClient(http_client)
         with self.assertRaises(CloseMethodCalled):
             http_client.close()
 


### PR DESCRIPTION
Note: This is a proof-of-concept, which means there is no guarantee that this behavior will be eventually included into MSAL Python.

There are two new APIs added.

* ~The high level API works for your confidential client which federated with a managed identity.~ This will be moved into a separated PR for its own consideration.
  ```python
   import msal
   cca = msal.ConfidentialClientApplication(
       "my_client_id",
       client_credential=msal.SystemAssignedManagedIdentity(),  # Or it can be an msal.UserAssignedManagedIdentity(client_id="guid")
       ...)
   result = cca.acquire_token_for_client(scopes["scope1", "scope2"])  # It uses scopes
  ```

* The low level API acquires token for managed identity

   ```python
   import msal, requests
   mi = msal.ManagedIdentityClient(
       msal.SystemAssignedManagedIdentity(),  # Or it can be an msal.UserAssignedManagedIdentity(client_id="guid")
       http_client=requests.Session(),  # This is a required parameter
       token_cache=msal.TokenCache(),  # Optional. In your production code, you shall persist a SerializableTokenCache https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache
   )
   result = mi.acquire_token_for_client(resource="resource_abc")  # It uses resource
   ```

More details of the new APIs are available [here](https://msal-python.readthedocs.io/en/mi/#managed-identity).

* In order to test this PR on Azure VM, you would need to:

  1. Create and then ssh into your Azure VM
  1. Install this proof-of-concept by `pip install --force-reinstall "git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@mi"`
  1. Write your script using the calling pattern above.

* To test this on App Service

  1. [Create your App Service with Python runtime](https://learn.microsoft.com/en-us/azure/app-service/quickstart-python?tabs=flask%2Cwindows%2Cazure-cli%2Clocal-git-deploy%2Cdeploy-instructions-azportal%2Cterminal-bash%2Cdeploy-instructions-zip-azcli#2---create-a-web-app-in-azure)
  2. [SSH into your App Service](https://learn.microsoft.com/en-us/azure/app-service/configure-linux-open-ssh-session)
  3. Follow the last two steps of Azure VM test method

* To test this on Azure Functions

  1. We have not yet tested it end-to-end, but the Managed Identity in Azure Function is expected to be the same as App Service.

* To test this on Azure Automation (we have not tested this)

  1. [Create your Automation account](https://learn.microsoft.com/en-us/azure/automation/automation-create-standalone-account?tabs=azureportal)
  3. You will need to install `msal` package. But it seems Azure Automation only supports [installing a package with its dependencies from PyPI](https://learn.microsoft.com/en-us/azure/automation/python-3-packages?tabs=py3#import-a-package-with-dependencies). This PR is not currently available from PyPI, so, we are unable to test this.
  4. After step 2, you can [create a new Python runbook](https://learn.microsoft.com/en-us/azure/automation/learn/automation-tutorial-runbook-textual-python-3) and test the Managed Identity

* To test this on Service Fabric

  1. We have not yet tested this end-to-end, but you can reference to the
     [test steps in Azure SDK](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/tests/managed-identity-live/service-fabric/service_fabric.md)

Note:

* At the end of [this internal document](https://microsoft.sharepoint.com/:w:/t/aad/devex/EXyuh-XFvj5EuoV6w8UuniUBQNg2EzQR5Ey7d_vbKPGayw?e=tTjoNQ), there are brief descriptions for the 6 variations of MIs.
* Cloud Shell's IMDS is NOT part of this PR, because we already provide a higher level API for it in `https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/420`.

Once merged, this PR will resolve #548. Also, it will officially close #487 as the callback is no longer needed.