### PR TITLE
Use provided authority port when building the tenant discovery endpoint

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -73,10 +73,9 @@ class Authority(object):
         authority, self.instance, tenant = canonicalize(authority_url)
 
         # extract authority port
-        parsedUrl = urlparse(authority_url)
-        authorityPort = parsedUrl.port
+        authorityPort = authority.port
 
-        if not authorityPort and parsedUrl.scheme == 'https':
+        if not authorityPort and authority.scheme == 'https':
             authorityPort = 443
 
         parts = authority.path.split('/')

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -71,13 +71,6 @@ class Authority(object):
         if isinstance(authority_url, AuthorityBuilder):
             authority_url = str(authority_url)
         authority, self.instance, tenant = canonicalize(authority_url)
-
-        # extract authority port
-        authorityPort = authority.port
-
-        if not authorityPort and authority.scheme == 'https':
-            authorityPort = 443
-
         parts = authority.path.split('/')
         is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or (
             len(parts) == 3 and parts[2].lower().startswith("b2c_"))
@@ -100,7 +93,7 @@ class Authority(object):
             tenant_discovery_endpoint = (
                 'https://{}:{}{}{}/.well-known/openid-configuration'.format(
                     self.instance,
-                    authorityPort,
+                    443 if authority.port is None else authority.port,
                     authority.path,  # In B2C scenario, it is "/tenant/policy"
                     "" if tenant == "adfs" else "/v2.0" # the AAD v2 endpoint
                     ))

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -71,6 +71,14 @@ class Authority(object):
         if isinstance(authority_url, AuthorityBuilder):
             authority_url = str(authority_url)
         authority, self.instance, tenant = canonicalize(authority_url)
+
+        # extract authority port
+        parsedUrl = urlparse(authority_url)
+        authorityPort = parsedUrl.port
+
+        if not authorityPort and parsedUrl.scheme == 'https':
+            authorityPort = 443
+
         parts = authority.path.split('/')
         is_b2c = any(self.instance.endswith("." + d) for d in WELL_KNOWN_B2C_HOSTS) or (
             len(parts) == 3 and parts[2].lower().startswith("b2c_"))
@@ -91,8 +99,9 @@ class Authority(object):
             tenant_discovery_endpoint = payload['tenant_discovery_endpoint']
         else:
             tenant_discovery_endpoint = (
-                'https://{}{}{}/.well-known/openid-configuration'.format(
+                'https://{}:{}{}{}/.well-known/openid-configuration'.format(
                     self.instance,
+                    authorityPort,
                     authority.path,  # In B2C scenario, it is "/tenant/policy"
                     "" if tenant == "adfs" else "/v2.0" # the AAD v2 endpoint
                     ))


### PR DESCRIPTION
Add support for authority (STS) endpoint hosted on non-443 port.  This allows Azure CLI to use STS and Graph hosted on different endpoints.  e.g.
```
>  az cloud show -n DevEnv
{
  "endpoints": {
    "activeDirectory": "https://localhost:3001",
    "activeDirectoryDataLakeResourceId": "https://datalake.azs/",
    "activeDirectoryGraphResourceId": "https://localhost:3002/v1.0/",
    "activeDirectoryResourceId": "https://login.azs",
...
  },
  "isActive": false,
  "name": "DevEnv",
  "profile": "latest",
  "suffixes": {
   ...
  }
}

```
This change will allow such configuration for Azure CLI and users can use az login to use it.

See https://github.com/Azure/azure-cli/issues/22553 for the error we get without this change.