### PR TITLE
Right regional endpoint for login.microsoft.com

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -526,8 +526,10 @@ class ClientApplication(object):
         if region_to_use:
             regional_host = ("{}.r.login.microsoftonline.com".format(region_to_use)
                 if central_authority.instance in (
-                    # The list came from https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/358/files#r629400328
+                    # The list came from point 3 of the algorithm section in this internal doc
+                    # https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/PinAuthToRegion/AAD%20SDK%20Proposal%20to%20Pin%20Auth%20to%20region.md&anchor=algorithm&_a=preview
                     "login.microsoftonline.com",
+                    "login.microsoft.com",
                     "login.windows.net",
                     "sts.windows.net",
                     )


### PR DESCRIPTION
We got it right in PR #358 based on the specs at that time, but we were using a fragile approach, which caused the "login.microsoft.com" being left out in subsequent PR #394.

Lesson learned. [Explicit is better than implicit](https://peps.python.org/pep-0020/)