### PR TITLE
Test latest 3.11 beta

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-alpha.5"]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11-dev"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR will change the test matrix to use the latest beta of Python 3.11 (currently b4) instead of alpha 5.