### PR TITLE
Disable authority alias lookup for ADFS-backed clouds

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1013,6 +1013,8 @@ class ClientApplication(object):
         return list(grouped_accounts.values())
 
     def _get_authority_aliases(self, instance):
+        if self.authority.is_adfs:
+            return []
         if not self.authority_groups:
             resp = self.http_client.get(
                 "https://login.microsoftonline.com/common/discovery/instance?api-version=1.1&authorization_endpoint=https://login.microsoftonline.com/common/oauth2/authorize",


### PR DESCRIPTION
MSAL PY already disables calls to AAD for ADFS-backed authority URIs, but missed the call for alias lookups. This call can only ever return an empty array or throw / crash the process if the public internet URL cannot be reached (as is the case in disconnected environments using a local ADFS identity solution). This fix skips that internet lookup and directly returns an empty array for ADFS authorities.

This fix is submitted to an experimental branch as MSAL PY will receive a larger design change later this year exposing configuration options which will include an explicit way to disable this alias lookup behavior. Because of that, this specific fix will **not** be directly included in any official MSAL PY releases as it is considered a behavioral change to disable this behavior without explicit config. After merging, customers who need to operate in a disconnected environment, or those who do not wish for this call to be made to the internet, can consume this fix by running ````pip install git+https://github.com/AzureAD/microsoft-authentication-library-for-python.git@experimental````