### PR TITLE
Implementing known_authority_hosts

### DIFF
--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -171,44 +171,39 @@ class TestMsalBehaviorsWithoutAndWithKnownAuthorityHosts(unittest.TestCase):
         app.get_accounts()  # This could make an instance metadata call for authority aliases
         instance_metadata.assert_not_called()
 
-    def test_known_authorities_should_allow_multiple_idempotent_calls_but_no_changes(self, *mocks):
-        known_hosts = ["contoso.com", "fabricam.com"]
-        msal.ClientApplication.set_known_authority_hosts(known_hosts)
-        msal.ClientApplication.set_known_authority_hosts(known_hosts)  # Allows idempotent calls
-        msal.ClientApplication.set_known_authority_hosts(
-            # Optional. Here we treat hosts orderless therefore accept equivalent call
-            reversed(known_hosts))
-        with self.assertRaises(ValueError):
-            msal.ClientApplication.set_known_authority_hosts(["hacked.com"])
-
     def test_known_authority_hosts_should_not_coexist_with_validate_authority_boolean(self, *mocks):
-        msal.ClientApplication.set_known_authority_hosts(["private.cloud"])
         with self.assertRaises(ValueError):
             msal.ClientApplication(
                 "id",
-                authority="https://unknown.com/common", validate_authority=False)
+                authority="https://unknown.com/common",
+                validate_authority=False, known_authority_hosts=["private.cloud"])
 
     def test_known_to_developer_authority_should_skip_validation_and_instance_metadata(
             self, instance_metadata, known_to_microsoft_validation, _):
-        msal.ClientApplication.set_known_authority_hosts(["private.cloud"])
-        app = msal.ClientApplication("foo", authority="https://private.cloud/foo")
+        app = msal.ClientApplication(
+            "foo",
+            authority="https://private.cloud/foo",
+            known_authority_hosts=["private.cloud"])
         known_to_microsoft_validation.assert_not_called()
         app.get_accounts()  # This could make an instance metadata call for authority aliases
         instance_metadata.assert_not_called()
 
     def test_known_to_developer_setting_should_still_let_a_known_to_microsoft_authority_skip_validation_and_use_instance_metadata(  # i.e. same as the without-known-to-developer behavior
             self, instance_metadata, known_to_microsoft_validation, _):
-        msal.ClientApplication.set_known_authority_hosts(["private.cloud"])
         app = msal.ClientApplication(
-            "id", authority="https://login.microsoftonline.com/common")
+            "id",
+            authority="https://login.microsoftonline.com/common",
+            known_authority_hosts=["private.cloud"])
         known_to_microsoft_validation.assert_not_called()
         app.get_accounts()  # This could make an instance metadata call for authority aliases
         instance_metadata.assert_called_once_with()
 
     def test_known_authorities_should_make_unknown_adfs_perform_validation_and_instance_metadata(
             self, instance_metadata, known_to_microsoft_validation, _):
-        msal.ClientApplication.set_known_authority_hosts(["private.cloud"])
-        app = msal.ClientApplication("foo", authority="https://unknown.com/adfs")
+        app = msal.ClientApplication(
+            "foo",
+            authority="https://unknown.com/adfs",
+            known_authority_hosts=["private.cloud"])
         known_to_microsoft_validation.assert_called_once_with(ANY, ANY)  # Python 3.5+
         # We effectively mocked a passed validation, so that MSAL will proceed
         app.get_accounts()  # This could make an instance metadata call for authority aliases
@@ -216,14 +211,12 @@ class TestMsalBehaviorsWithoutAndWithKnownAuthorityHosts(unittest.TestCase):
 
     def test_known_authorities_should_make_unknown_b2c_perform_validation_and_instance_metadata(
             self, instance_metadata, known_to_microsoft_validation, _):
-        msal.ClientApplication.set_known_authority_hosts(["private.cloud"])
-        app = msal.ClientApplication("foo", authority="https://b2clogin.com/contoso/b2c_policy")
+        app = msal.ClientApplication(
+            "foo",
+            authority="https://b2clogin.com/contoso/b2c_policy",
+            known_authority_hosts=["private.cloud"])
         known_to_microsoft_validation.assert_called_once_with(ANY, ANY)  # Python 3.5+
         # We effectively mocked a passed validation, so that MSAL will proceed
         app.get_accounts()  # This could make an instance metadata call for authority aliases
         instance_metadata.assert_called_once_with()
-
-    def tearDown(self):
-        # This is not part of public API. We do it here only for unit-testing.
-        msal.ClientApplication._known_authority_hosts = None  # Reset
 


### PR DESCRIPTION
Implementing the known_authorities behaviors based on the [internal design](https://microsoft.sharepoint.com/:w:/t/ADAL/ESzbQvzlMuBDjAsqfaHdjNUBsTmwIUR5g17IAY4rvOY_Hw?e=7dv5hZ).

The [unit tests of this PR](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/492/files#diff-1982837bc801e709175e25839e1046a445df689d7a2e6309ccb6856e350dee7eR142-R223) is almost as readable as plain English, and are considered as generic acceptance tests for this feature.

This PR also contains the ["api reference documentation" for the newly introduced `known_authority_hosts` parameter](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/492/files#diff-4d32d284fa6acf43894719eff11cb366e5969e0b61593bfd00c68a4cf9c441caR165-R185).

When merged, this PR will close this [internal workitem](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/823221).

---

This entire PR has been shelved, because later we discovered some [new requirements for Azure Stack scenarios (internal link)](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=/AuthorityValidation/authority_validation_concepts_and_api.md&_a=preview&anchor=skip-authority-validation-and-alias-metadata-behaviors-without-a-set-of-predefined-authorities), so we proceeded with #496.