### PR TITLE
Update setup.cfg with documentation URL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,5 @@ universal=1
 project_urls =
     Changelog = https://github.com/AzureAD/microsoft-authentication-library-for-python/releases
     Documentation = https://msal-python.readthedocs.io/
+    Questions = https://stackoverflow.com/questions/tagged/msal+python
+    Feature/Bug Tracker = https://github.com/AzureAD/microsoft-authentication-library-for-python/issues

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ universal=1
 [metadata]
 project_urls =
     Changelog = https://github.com/AzureAD/microsoft-authentication-library-for-python/releases
+    Documentation = https://msal-python.readthedocs.io/


### PR DESCRIPTION
It'd be nice if pypi.org showed a link to the documentation. I think this is how it's specified, but all the docs these days show pyproject.toml, not setup.cfg, so I'm not positive.

See also https://github.com/rayluo/identity/pull/1