### PR TITLE
Fix Markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Not sure whether this is the SDK you are looking for your app? There are other M
 
 Quick links:
 
-| [Getting Started](https://learn.microsoft.com/azure/active-directory/develop/web-app-quickstart?pivots=devlang-python| [Docs](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki) | [Samples](https://aka.ms/aaddevsamplesv2) | [Support](README.md#community-help-and-support) | [Feedback](https://forms.office.com/r/TMjZkDbzjY) |
+| [Getting Started](https://learn.microsoft.com/azure/active-directory/develop/web-app-quickstart?pivots=devlang-python)| [Docs](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki) | [Samples](https://aka.ms/aaddevsamplesv2) | [Support](README.md#community-help-and-support) | [Feedback](https://forms.office.com/r/TMjZkDbzjY) |
 | --- | --- | --- | --- | --- |
 
 ## Scenarios supported


### PR DESCRIPTION
The link is currently broken due to missing parenthesis.

Notably, it links to an article that will now use the identity library, the MSAL wrapper, versus MSAL directly. Maybe that's okay? 