### PR TITLE
WIP: Supporting https://login.ciamlogin.com/tenant.onmicrosoft.com

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -28,6 +28,7 @@ WELL_KNOWN_B2C_HOSTS = [
     "b2clogin.cn",
     "b2clogin.us",
     "b2clogin.de",
+    "ciamlogin.com",
     ]
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -897,6 +897,9 @@ class CiamTestCase(LabBasedTestCase):
         # FYI: Only single- or multi-tenant CIAM app can have other-than-OIDC
         # delegated permissions on Microsoft Graph.
         cls.app_config = cls.get_lab_app_object(cls.user["client_id"])
+        cls.app_config["authority"] = cls.app_config["authority"].replace(
+            "microsoftonline", "ciamlogin")
+        print(cls.app_config["authority"])
 
     def test_ciam_acquire_token_interactive(self):
         self._test_acquire_token_interactive(


### PR DESCRIPTION
The automation tests currently fail only because that domain name is not accessible.