### PR TITLE
Supporting https://contoso.ciamlogin.com as authority

### DIFF
--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -79,6 +79,26 @@ class TestAuthority(unittest.TestCase):
             pass  # Those are expected for this unittest case
 
 
+@patch("msal.authority.tenant_discovery", return_value={
+    "authorization_endpoint": "https://contoso.com/placeholder",
+    "token_endpoint": "https://contoso.com/placeholder",
+    })
+class TestCiamAuthority(unittest.TestCase):
+    http_client = MinimalHttpClient()
+
+    def test_path_less_authority_should_work(self, oidc_discovery):
+        Authority('https://contoso.ciamlogin.com', self.http_client)
+        oidc_discovery.assert_called_once_with(
+            "https://contoso.ciamlogin.com/contoso.onmicrosoft.com/v2.0/.well-known/openid-configuration",
+            self.http_client)
+
+    def test_authority_with_path_should_be_used_as_is(self, oidc_discovery):
+        Authority('https://contoso.ciamlogin.com/anything', self.http_client)
+        oidc_discovery.assert_called_once_with(
+            "https://contoso.ciamlogin.com/anything/v2.0/.well-known/openid-configuration",
+            self.http_client)
+
+
 class TestAuthorityInternalHelperCanonicalize(unittest.TestCase):
 
     def test_canonicalize_tenant_followed_by_extra_paths(self):


### PR DESCRIPTION
The automation tests ~currently fail because~ passes:

* ~the new domain name is unavailable~
* ~the OIDC discovery endpoint is not available. When it is available, it is expected to also be in the ".../v2.0/..." endpoint.~
* ~we will continue the prototyping after the above two become available~
* ~Waiting on new lab api~
* New [lab api](https://msidlab.com/api/app/b8e9d222-c4ee-414c-ac29-b0eff1f32400) has been updated to return a new authority

Testers shall take a look into logs to double check your auth/token requests were sent out to `https://msidlabciam1.ciamlogin.com/d57fb3d4-4b5a-4144-9328-9c1f7d58179d/oauth2/v2.0/token?dc=ESTS-PUB-EUS-AZ1-FD000-TEST1` which was discovered from [OIDC discovery](https://msidlabciam1.ciamlogin.com/msidlabciam1.onmicrosoft.com/v2.0/.well-known/openid-configuration?dc=ESTS-PUB-EUS-AZ1-FD000-TEST1). If an MSAL you are working on does not obtain those endpoints from OIDC discovery, you could probably use `https://msidlabciam1.ciamlogin.com/TENANT.ONMICROSOFT.COM/oauth2/v2.0/token?dc=ESTS-PUB-EUS-AZ1-FD000-TEST1` instead.