### PR TITLE
2+ hrs AT will have refresh_in default to expires_in/2

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -187,8 +187,8 @@ class TokenCache(object):
                     }
                 if data.get("key_id"):  # It happens in SSH-cert or POP scenario
                     at["key_id"] = data.get("key_id")
-                if "refresh_in" in response:
-                    refresh_in = response["refresh_in"]  # It is an integer
+                if "refresh_in" in response or expires_in > 7200:
+                    refresh_in = int(response.get("refresh_in", expires_in / 2))
                     at["refresh_on"] = str(now + refresh_in)  # Schema wants a string
                 self.modify(self.CredentialType.ACCESS_TOKEN, at, at)
 


### PR DESCRIPTION
@bgavrilMS , @gladjohn , looks like you have also started the work on expires_in. I figure I better also pick up the work at the same time, so that we will have same context while reviewing each other's PR.

The new behavior is "refresh_in = expires_in / 2 when and only when refresh_in is absent and expires_in > 7200".

Currently, as a proof-of-concept, this PR in MSAL Python tentatively brings such a new behavior to all ATs, not just managed identity. It feels harmless, because ESTS remains in control, as they can always emit an explicit refresh_in to override MSAL's default behavior.

P.S.: I'll also add a similar commit into my another work-in-progress Managed Identity PR.