### PR TITLE
Clarify that allow_broker is not applicable to ConfidentialClientApplication

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -444,6 +444,8 @@ class ClientApplication(object):
             New in version 1.19.0.
 
         :param boolean allow_broker:
+            This parameter is NOT applicable to :class:`ConfidentialClientApplication`.
+
             A broker is a component installed on your device.
             Broker implicitly gives your device an identity. By using a broker,
             your device becomes a factor that can satisfy MFA (Multi-factor authentication).


### PR DESCRIPTION
Although MSAL provides two top-level classes: PublicClientApplication and ConfidentialClientApplication, there is another less-popular but still-doable pattern which is to use the base class ClientApplication directly. So, that `allow_broker` is applicable to both PublicClientApplication and the base class ClientApplication. So, that dynamic check in base class is necessary.

The ConfidentialClientApplication inherits the `__init__()` and its documentation from base class. Now, we choose to add a sentence in that documentation to clarify that the parameter is not applicable to ConfidentialClientApplication.

See it in action in [the staged documentation](https://msal-python.readthedocs.io/en/docs-staging/#msal.ConfidentialClientApplication.params.allow_broker).

This resolves #544.