### PR TITLE
Adjustment for new CIAM partition

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -925,10 +925,16 @@ class CiamTestCase(LabBasedTestCase):
             client_secret=self.get_lab_user_secret(
                 self.app_config["clientSecret"].split("=")[-1]),
             authority=self.app_config["authority"],
-            scope=["{}/.default".format(self.app_config["appId"])],  # App permission
+            #scope=["{}/.default".format(self.app_config["appId"])],  # AADSTS500207: The account type can't be used for the resource you're trying to access.
+            #scope=["api://{}/.default".format(self.app_config["appId"])],  # AADSTS500011: The resource principal named api://ced781e7-bdb0-4c99-855c-d3bacddea88a was not found in the tenant named MSIDLABCIAM2. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant.
+            scope=self.app_config["scopes"],  # It shall ends with "/.default"
             )
 
     def test_ciam_acquire_token_by_ropc(self):
+        """CIAM does not officially support ROPC, especially not for external emails.
+
+        We keep this test case for now, because the test data will use a local email.
+        """
         # Somehow, this would only work after creating a secret for the test app
         # and enabling "Allow public client flows".
         # Otherwise it would hit AADSTS7000218.


### PR DESCRIPTION
Our lab switched to a new CIAM test tenant.

The two lab API were also updated:
1. [Get a test user and its test app from lab](https://msidlab.com/api/User?federationprovider=ciam&signInAudience=azureadmyorg&PublicClient=No) (Same API, different value in response)
2. [Get that app's authority and scope](https://msidlab.com/api/app/ced781e7-bdb0-4c99-855c-d3bacddea88a). Note: You shall NOT hardcode the test app's client id "ced7..." into your test case's source code or even configuration file. Instead, read it on-the-fly from the `appId` field from the response of the first API above. This way, in the future when/if the lab switch to a different client_id, your existing test automation will not break.

There is one change needed in the Confidential Client's test case. No more hardcoded scope. The scope returned from lab API 2 will work out of the box.