### PR TITLE
acquire_token_silent() shall not invoke broker if the account was not established by broker

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -5,9 +5,11 @@ import logging
 
 from .authority import canonicalize
 from .oauth2cli.oidc import decode_part, decode_id_token
+from .oauth2cli.oauth2 import Client
 
 
 logger = logging.getLogger(__name__)
+_GRANT_TYPE_BROKER = "broker"
 
 def is_subdict_of(small, big):
     return dict(big, **small) == big
@@ -210,6 +212,11 @@ class TokenCache(object):
                             else self.AuthorityType.MSSTS),
                     # "client_info": response.get("client_info"),  # Optional
                     }
+                grant_types_that_establish_an_account = (
+                    _GRANT_TYPE_BROKER, "authorization_code", "password",
+                    Client.DEVICE_FLOW["GRANT_TYPE"])
+                if event.get("grant_type") in grant_types_that_establish_an_account:
+                    account["account_source"] = event["grant_type"]
                 self.modify(self.CredentialType.ACCOUNT, account, account)
 
             if id_token:

--- a/tests/test_account_source.py
+++ b/tests/test_account_source.py
@@ -1,0 +1,79 @@
+import json
+try:
+    from unittest.mock import patch
+except:
+    from mock import patch
+try:
+    import pymsalruntime
+    broker_available = True
+except ImportError:
+    broker_available = False
+import msal
+from tests import unittest
+from tests.test_token_cache import build_response
+from tests.http_client import MinimalResponse
+
+
+SCOPE = "scope_foo"
+TOKEN_RESPONSE = build_response(
+    access_token="at",
+    uid="uid", utid="utid",  # So that it will create an account
+    scope=SCOPE, refresh_token="rt",  # So that non-broker's acquire_token_silent() would work
+)
+
+def _mock_post(url, headers=None, *args, **kwargs):
+    return MinimalResponse(status_code=200, text=json.dumps(TOKEN_RESPONSE))
+
+@unittest.skipUnless(broker_available, "These test cases need pip install msal[broker]")
+@patch("msal.broker._acquire_token_silently", return_value=dict(
+    TOKEN_RESPONSE, _account_id="placeholder"))
+@patch.object(msal.authority, "tenant_discovery", return_value={
+    "authorization_endpoint": "https://contoso.com/placeholder",
+    "token_endpoint": "https://contoso.com/placeholder",
+})  # Otherwise it would fail on OIDC discovery
+class TestAccountSourceBehavior(unittest.TestCase):
+
+    def test_device_flow_and_its_silent_call_should_bypass_broker(self, _, mocked_broker_ats):
+        app = msal.PublicClientApplication("client_id", enable_broker_on_windows=True)
+        result = app.acquire_token_by_device_flow({"device_code": "123"}, post=_mock_post)
+        self.assertEqual(result["token_source"], "identity_provider")
+
+        account = app.get_accounts()[0]
+        self.assertEqual(account["account_source"], "urn:ietf:params:oauth:grant-type:device_code")
+
+        result = app.acquire_token_silent_with_error(
+            [SCOPE], account, force_refresh=True, post=_mock_post)
+        mocked_broker_ats.assert_not_called()
+        self.assertEqual(result["token_source"], "identity_provider")
+
+    def test_ropc_flow_and_its_silent_call_should_bypass_broker(self, _, mocked_broker_ats):
+        app = msal.PublicClientApplication("client_id", enable_broker_on_windows=True)
+        with patch.object(app.authority, "user_realm_discovery", return_value={}):
+            result = app.acquire_token_by_username_password(
+                "username", "placeholder", [SCOPE], post=_mock_post)
+        self.assertEqual(result["token_source"], "identity_provider")
+
+        account = app.get_accounts()[0]
+        self.assertEqual(account["account_source"], "password")
+
+        result = app.acquire_token_silent_with_error(
+            [SCOPE], account, force_refresh=True, post=_mock_post)
+        mocked_broker_ats.assert_not_called()
+        self.assertEqual(result["token_source"], "identity_provider")
+
+    def test_interactive_flow_and_its_silent_call_should_invoke_broker(self, _, mocked_broker_ats):
+        app = msal.PublicClientApplication("client_id", enable_broker_on_windows=True)
+        with patch.object(app, "_acquire_token_interactive_via_broker", return_value=dict(
+                TOKEN_RESPONSE, _account_id="placeholder")):
+            result = app.acquire_token_interactive(
+                [SCOPE], parent_window_handle=app.CONSOLE_WINDOW_HANDLE)
+        self.assertEqual(result["token_source"], "broker")
+
+        account = app.get_accounts()[0]
+        self.assertEqual(account["account_source"], "broker")
+
+        result = app.acquire_token_silent_with_error(
+            [SCOPE], account, force_refresh=True, post=_mock_post)
+        mocked_broker_ats.assert_called_once()
+        self.assertEqual(result["token_source"], "broker")
+


### PR DESCRIPTION
This is useful when the user somehow chose to use device code flow successfully and now want to do an acquire_token_silent(). The event sequence in this scenario looks like this:

1. End user enabled broker.
2. For whatever reason, end user chooses to sign in using Device Code Flow (DCF). Broker (WAM) does not support DCF but, per our existing design, we do not want to break this scenario, so MSAL automatically falls back to use native DCF implementation. This is already happening today, and the sign-in would be successful, and access token (AT) and refresh token (RT) will be stored inside MSAL's native token cache.
3. Subsequent AcquireTokenSilent() call (especially those after the initial access token expires) would attempt broker code path, and end up with an "account not found" error from MsalRuntime's `read_account_by_id()` call, because the account was not established via MsalRuntime code path in step 2.
4. Currently, MSAL's AcquireTokenSilent() surfaces that MsalRuntime error to calling app, and that results in end user's token refresh attempt failure.
5. ~Per our recent discussion (in May 2023) with Azure CLI team and MsalRuntime team, this PR changes to catch error in step 3, and falls back to native token cache, whose RT will work.~
6. Per our recent discussion (in Nov 1st, 2023) with MSAL C++ team, this PR changes to record which flow established an account, and then bypass broker in its subsequent `acquire_token_silent()` calls. Also applies the same treatment to Username Password flow (a.k.a. ROPC). You may review this [internal design doc here](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/10474).

Note: Most of the conversation below between June to October were based on the outdated bullet point No.5, so, you do not need to read them.

@msamwils, you do not have to review the implementation details in this PR (which contains some other logistic changes), but please review the summary above.