### PR TITLE
Expose token_source for observability

### DIFF
--- a/sample/confidential_client_certificate_sample.py
+++ b/sample/confidential_client_certificate_sample.py
@@ -63,6 +63,7 @@ def acquire_and_use_token():
     result = global_app.acquire_token_for_client(scopes=config["scope"])
 
     if "access_token" in result:
+        print("Token was obtained from:", result["token_source"])  # Since MSAL 1.25
         # Calling graph using the access token
         graph_data = requests.get(  # Use token to call downstream service
             config["endpoint"],

--- a/sample/confidential_client_secret_sample.py
+++ b/sample/confidential_client_secret_sample.py
@@ -62,6 +62,7 @@ def acquire_and_use_token():
     result = global_app.acquire_token_for_client(scopes=config["scope"])
 
     if "access_token" in result:
+        print("Token was obtained from:", result["token_source"])  # Since MSAL 1.25
         # Calling graph using the access token
         graph_data = requests.get(  # Use token to call downstream service
             config["endpoint"],

--- a/sample/device_flow_sample.py
+++ b/sample/device_flow_sample.py
@@ -84,6 +84,7 @@ def acquire_and_use_token():
             # and then keep calling acquire_token_by_device_flow(flow) in your own customized loop.
 
     if "access_token" in result:
+        print("Token was obtained from:", result["token_source"])  # Since MSAL 1.25
         # Calling graph using the access token
         graph_data = requests.get(  # Use token to call downstream service
             config["endpoint"],

--- a/sample/interactive_sample.py
+++ b/sample/interactive_sample.py
@@ -79,6 +79,7 @@ def acquire_and_use_token():
             )
 
     if "access_token" in result:
+        print("Token was obtained from:", result["token_source"])  # Since MSAL 1.25
         # Calling graph using the access token
         graph_response = requests.get(  # Use token to call downstream service
             config["endpoint"],

--- a/sample/username_password_sample.py
+++ b/sample/username_password_sample.py
@@ -66,6 +66,7 @@ def acquire_and_use_token():
             config["username"], config["password"], scopes=config["scope"])
 
     if "access_token" in result:
+        print("Token was obtained from:", result["token_source"])  # Since MSAL 1.25
         # Calling graph using the access token
         graph_data = requests.get(  # Use token to call downstream service
             config["endpoint"],

--- a/sample/vault_jwt_sample.py
+++ b/sample/vault_jwt_sample.py
@@ -125,6 +125,7 @@ def acquire_and_use_token():
     result = global_app.acquire_token_for_client(scopes=config["scope"])
 
     if "access_token" in result:
+        print("Token was obtained from:", result["token_source"])  # Since MSAL 1.25
         # Calling graph using the access token
         graph_data = requests.get(  # Use token to call downstream service
             config["endpoint"],


### PR DESCRIPTION
This will address #602 's first requirement. The successful token acquisition result will have a new key `token_source` whose value will be `idp`, `cache` or `broker`.

Existing unit test cases have been updated to test this new behavior.