### PR TITLE
Deprecate allow_broker, use enable_broker_on_windows

### DIFF
--- a/msal/__main__.py
+++ b/msal/__main__.py
@@ -190,9 +190,9 @@ def _main():
         option_renderer=lambda a: a["name"],
         header="Impersonate this app (or you can type in the client_id of your own app)",
         accept_nonempty_string=True)
-    allow_broker = _input_boolean("Allow broker?")
+    enable_broker = _input_boolean("Enable broker? It will error out later if your app has not registered some redirect URI")
     enable_debug_log = _input_boolean("Enable MSAL Python's DEBUG log?")
-    enable_pii_log = _input_boolean("Enable PII in broker's log?") if allow_broker and enable_debug_log else False
+    enable_pii_log = _input_boolean("Enable PII in broker's log?") if enable_broker and enable_debug_log else False
     app = msal.PublicClientApplication(
         chosen_app["client_id"] if isinstance(chosen_app, dict) else chosen_app,
         authority=_select_options([
@@ -205,7 +205,7 @@ def _main():
             header="Input authority (Note that MSA-PT apps would NOT use the /common authority)",
             accept_nonempty_string=True,
             ),
-        allow_broker=allow_broker,
+        enable_broker_on_windows=enable_broker,
         enable_pii_log=enable_pii_log,
         )
     if enable_debug_log:

--- a/sample/interactive_sample.py
+++ b/sample/interactive_sample.py
@@ -37,8 +37,8 @@ global_token_cache = msal.TokenCache()  # The TokenCache() is in-memory.
 # Create a preferably long-lived app instance, to avoid the overhead of app creation
 global_app = msal.PublicClientApplication(
     config["client_id"], authority=config["authority"],
-    #allow_broker=True,  # If opted in, you will be guided to meet the prerequisites, when applicable
-                         # See also: https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-wam#wam-value-proposition
+    #enable_broker_on_windows=True,  # Opted in. You will be guided to meet the prerequisites, if your app hasn't already
+        # See also: https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token-wam#wam-value-proposition
     token_cache=global_token_cache,  # Let this app (re)use an existing token cache.
         # If absent, ClientApplication will create its own empty token cache
     )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -165,21 +165,27 @@ class E2eTestCase(unittest.TestCase):
             http_client=None,
             azure_region=None,
             **kwargs):
-        try:
-            import pymsalruntime
-            broker_available = True
-        except ImportError:
-            broker_available = False
-        return (msal.ConfidentialClientApplication
-                if client_credential else msal.PublicClientApplication)(
-            client_id,
-            client_credential=client_credential,
-            authority=authority,
-            azure_region=azure_region,
-            http_client=http_client or MinimalHttpClient(),
-            allow_broker=broker_available  # This way, we reuse same test cases, by run them with and without broker
-                and not client_credential,
+        if client_credential:
+            return msal.ConfidentialClientApplication(
+                client_id,
+                client_credential=client_credential,
+                authority=authority,
+                azure_region=azure_region,
+                http_client=http_client or MinimalHttpClient(),
             )
+        else:
+            # Reuse same test cases, by run them with and without broker
+            try:
+                import pymsalruntime
+                broker_available = True
+            except ImportError:
+                broker_available = False
+            return msal.PublicClientApplication(
+                client_id,
+                authority=authority,
+                http_client=http_client or MinimalHttpClient(),
+                enable_broker_on_windows=broker_available,
+                )
 
     def _test_username_password(self,
             authority=None, client_id=None, username=None, password=None, scope=None,


### PR DESCRIPTION
This PR deprecates the old `ClientApplication.__init__(..., allow_broker=True)`. Please use `PublicClientApplication.__init__(..., enable_broker_on_windows=True)` instead.

This change is the first step for us to moving to per-platform opt-in flag.

This PR will also close #510 , because we no longer go with that direction.

@jiasli , @xiangyan99,
* You do not have to immediately make a dependency on this change, but you are still recommended to expose the per-platform opt-in flag in your code base accordingly
* Please run your smoke test with this PR, as it will likely become the last change in an upcoming MSAL Python 1.25
