### PR TITLE
Remove newlines from description / Fix summary.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,7 @@ universal=1
 [metadata]
 name = msal
 version = attr: msal.__version__
-description =
-    The Microsoft Authentication Library (MSAL) for Python library
-    enables your app to access the Microsoft Cloud
-    by supporting authentication of users with
-    Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA)
-    using industry standard OAuth2 and OpenID Connect.
+description = The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect.
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = MIT


### PR DESCRIPTION
When trying to build wheel it gives warning
```
writing msal.egg-info/PKG-INFO
/usr/lib/python3.11/site-packages/setuptools/dist.py:173: SetuptoolsDeprecationWarning: Invalid config.
!!

        ********************************************************************************
        newlines are not allowed in `summary` and will break in the future
        ********************************************************************************

!!
  write_field('Summary', single_line(summary))
```

This can be seen in latest wheel on pypi `msal-1.25.0-py2.py3-none-any.whl`
summary field in METADATA file is incomplete, it only states:
`Summary: The Microsoft Authentication Library (MSAL) for Python library`