### PR TITLE
Don't use bare except when importing

### DIFF
--- a/msal/mex.py
+++ b/msal/mex.py
@@ -27,7 +27,7 @@
 
 try:
     from urllib.parse import urlparse
-except:
+except ImportError:
     from urlparse import urlparse
 try:
     from xml.etree import cElementTree as ET


### PR DESCRIPTION
Using a bare except statement when importing hides other errors, which then get lost when the next import fails.