### PR TITLE
Update the default broker redirect URI to be a valid URI

### DIFF
--- a/msal/broker.py
+++ b/msal/broker.py
@@ -169,8 +169,9 @@ def _signin_interactively(
         **kwargs):
     params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
     params.set_requested_scopes(scopes)
-    params.set_redirect_uri("placeholder")  # pymsalruntime 0.1 requires non-empty str,
-        # the actual redirect_uri will be overridden by a value hardcoded by the broker
+    params.set_redirect_uri("https://login.microsoftonline.com/common/oauth2/nativeclient")
+        # This default redirect_uri value is not currently used by the broker
+        # but it is required by the MSAL.cpp to be set to a non-empty valid URI.
     if prompt:
         if prompt == "select_account":
             if login_hint:


### PR DESCRIPTION
MSAL.cpp fixed the URI parsing logic to not allow invalid URIs which causes the default redirect URI to not be properly set when calling MSAL.runtime. This caused the sev2 ICM with azcli.

Chaning the default to be the default RU for native clients: https://login.microsoftonline.com/common/oauth2/nativeclient