### PR TITLE
MSAL Python 1.28.0

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -25,7 +25,7 @@ from .cloudshell import _is_running_in_cloud_shell
 
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.27.0"  # When releasing, also check and bump our dependencies's versions if needed
+__version__ = "1.28.0"  # When releasing, also check and bump our dependencies's versions if needed
 
 logger = logging.getLogger(__name__)
 _AUTHORITY_TYPE_CLOUDSHELL = "CLOUDSHELL"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # Format https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
 
 [bdist_wheel]
-universal=1
+universal=0
 
 [metadata]
 name = msal
@@ -16,11 +16,8 @@ url = https://github.com/AzureAD/microsoft-authentication-library-for-python
 classifiers =
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -40,7 +37,8 @@ project_urls =
 [options]
 include_package_data = False  # We used to ship LICENSE, but our __init__.py already mentions MIT
 packages = find:
-python_requires = >=2.7
+# Our test pipeline currently still covers Py37
+python_requires = >=3.7
 install_requires =
     requests>=2.0.0,<3
 
@@ -56,7 +54,6 @@ install_requires =
     # https://cryptography.io/en/latest/api-stability/#deprecation
     cryptography>=0.6,<45
 
-    mock; python_version<'3.3'
 
 [options.extras_require]
 broker =

--- a/tests/broker-test.py
+++ b/tests/broker-test.py
@@ -1,0 +1,66 @@
+"""This script is used to impersonate Azure CLI
+and run 3 pairs of end-to-end tests with broker.
+Although not fully automated, it requires only several clicks to finish.
+
+Each time a new PyMsalRuntime is going to be released,
+we can use this script to test it with a given version of MSAL Python.
+"""
+import msal
+
+_AZURE_CLI = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+SCOPE_ARM = "https://management.azure.com/.default"
+placeholder_auth_scheme = msal.PopAuthScheme(
+    http_method=msal.PopAuthScheme.HTTP_GET,
+    url="https://example.com/endpoint",
+    nonce="placeholder",
+    )
+_JWK1 = """{"kty":"RSA", "n":"2tNr73xwcj6lH7bqRZrFzgSLj7OeLfbn8216uOMDHuaZ6TEUBDN8Uz0ve8jAlKsP9CQFCSVoSNovdE-fs7c15MxEGHjDcNKLWonznximj8pDGZQjVdfK-7mG6P6z-lgVcLuYu5JcWU_PeEqIKg5llOaz-qeQ4LEDS4T1D2qWRGpAra4rJX1-kmrWmX_XIamq30C9EIO0gGuT4rc2hJBWQ-4-FnE1NXmy125wfT3NdotAJGq5lMIfhjfglDbJCwhc8Oe17ORjO3FsB5CLuBRpYmP7Nzn66lRY3Fe11Xz8AEBl3anKFSJcTvlMnFtu3EpD-eiaHfTgRBU7CztGQqVbiQ", "e":"AQAB"}"""
+_SSH_CERT_DATA = {"token_type": "ssh-cert", "key_id": "key1", "req_cnf": _JWK1}
+_SSH_CERT_SCOPE = "https://pas.windows.net/CheckMyAccess/Linux/.default"
+
+pca = msal.PublicClientApplication(
+    _AZURE_CLI,
+    authority="https://login.microsoftonline.com/organizations",
+    enable_broker_on_windows=True)
+
+def interactive_and_silent(scopes, auth_scheme, data, expected_token_type):
+    print("An account picker shall be pop up, possibly behind this console. Continue from there.")
+    result = pca.acquire_token_interactive(
+        scopes,
+        prompt="select_account",  # "az login" does this
+        parent_window_handle=pca.CONSOLE_WINDOW_HANDLE,  # This script is a console app
+        enable_msa_passthrough=True,  # Azure CLI is an MSA-passthrough app
+        auth_scheme=auth_scheme,
+        data=data or {},
+        )
+    _assert(result, expected_token_type)
+
+    accounts = pca.get_accounts()
+    assert accounts, "The logged in account should have been established by interactive flow"
+    result = pca.acquire_token_silent(
+        scopes,
+        account=accounts[0],
+        force_refresh=True,  # Bypass MSAL Python's token cache to test PyMsalRuntime
+        auth_scheme=auth_scheme,
+        data=data or {},
+        )
+    _assert(result, expected_token_type)
+
+def _assert(result, expected_token_type):
+    assert result.get("access_token"), f"We should obtain a token. Got {result} instead."
+    assert result.get("token_source") == "broker", "Token should be obtained via broker"
+    assert result.get("token_type").lower() == expected_token_type.lower(), f"{expected_token_type} not found"
+
+for i in range(2):  # Mimic Azure CLI's issue report
+    interactive_and_silent(
+        scopes=[SCOPE_ARM], auth_scheme=None, data=None, expected_token_type="bearer")
+
+interactive_and_silent(
+    scopes=[SCOPE_ARM], auth_scheme=placeholder_auth_scheme, data=None, expected_token_type="pop")
+interactive_and_silent(
+    scopes=[_SSH_CERT_SCOPE],
+    data=_SSH_CERT_DATA,
+    auth_scheme=None,
+    expected_token_type="ssh-cert",
+    )
+


### PR DESCRIPTION
* New feature: `PublicClientApplication` and `ConfidentialClientApplication` have a new `oidc_authority` parameter that can be used to specify authority of any generic OpenID Connect authority, typically the customized domain for CIAM. (#676, #678)
* Dropping Python 2.7