### PR TITLE
Add KID check when getting a token from cache

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -1386,6 +1386,9 @@ class ClientApplication(object):
                 if expires_in < 5*60:  # Then consider it expired
                     refresh_reason = msal.telemetry.AT_EXPIRED
                     continue  # Removal is not necessary, it will be overwritten
+                if key_id and entry.get("key_id") != key_id:
+                    refresh_reason = msal.telemetry.AT_EXPIRED
+                    continue  # If the Key_Id is not matching, then it is not the token we are looking for
                 logger.debug("Cache hit an AT")
                 access_token_from_cache = {  # Mimic a real response
                     "access_token": entry["secret"],

--- a/msal/application.py
+++ b/msal/application.py
@@ -1387,7 +1387,7 @@ class ClientApplication(object):
                     refresh_reason = msal.telemetry.AT_EXPIRED
                     continue  # Removal is not necessary, it will be overwritten
                 if key_id and entry.get("key_id") != key_id:
-                    refresh_reason = msal.telemetry.AT_EXPIRED
+                    refresh_reason = msal.telemetry.AT_ABSENT
                     continue  # If the Key_Id is not matching, then it is not the token we are looking for
                 logger.debug("Cache hit an AT")
                 access_token_from_cache = {  # Mimic a real response


### PR DESCRIPTION
We have encountered an issue with how MSAL is caching Tokens that have a KID. 

The issue is:

- Say you have a Token with ClientID (AAAA..) and KID (11111..) which gets cached. And returned when needed. So far no problem.
- If you then come and try to get a token for ClientID (AAAA..) and KID (22222..) the expected behavior would be to get a new token since the KID has changed.
- This is does not happen. Although the _find method takes in the "key_id" as a query parameter the query will still return tokens that only match the client ID. And there is no additional check to ensure the "key_id" is the same one. 

The solution:

A quick check when getting a token from cache. If a KeyID is present it should match the one provided. 

I validated these changes locally and they solve the issue. For reference here is the code we use: https://github.com/Azure/azure-cli-extensions/blob/2a1898ff1b70153df2311ccb784a90751914c0b1/src/connectedk8s/azext_connectedk8s/_clientproxyutils.py#L86

We have an open ICM with more context: https://portal.microsofticm.com/imp/v3/incidents/incident/494360176/summary