### PR TITLE
Update ROPC broker related tests

### DIFF
--- a/tests/broker-test.py
+++ b/tests/broker-test.py
@@ -46,6 +46,15 @@ def interactive_and_silent(scopes, auth_scheme, data, expected_token_type):
         )
     _assert(result, expected_token_type)
 
+def test_broker_username_password(scopes, expected_token_type):
+    print("Testing broker username password flows by using labs account: 'fidlab@msidlab4.com', please provide the password.")
+    username = "fidlab@msidlab4.com"
+    password = input("Password:")
+    result = pca.acquire_token_by_username_password(username, password, scopes)
+    _assert(result, expected_token_type)
+    assert(result.get("token_source") == "broker")
+    print("Username password test succeeds.")
+
 def _assert(result, expected_token_type):
     assert result.get("access_token"), f"We should obtain a token. Got {result} instead."
     assert result.get("token_source") == "broker", "Token should be obtained via broker"
@@ -64,3 +73,4 @@ interactive_and_silent(
     expected_token_type="ssh-cert",
     )
 
+test_broker_username_password(scopes=[SCOPE_ARM], expected_token_type="bearer")

--- a/tests/broker-test.py
+++ b/tests/broker-test.py
@@ -6,6 +6,12 @@ Each time a new PyMsalRuntime is going to be released,
 we can use this script to test it with a given version of MSAL Python.
 """
 import msal
+import os
+try:
+    from dotenv import load_dotenv  # Use this only in local dev machine
+    load_dotenv()  # take environment variables from .env.
+except:
+    pass
 
 _AZURE_CLI = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 SCOPE_ARM = "https://management.azure.com/.default"
@@ -47,9 +53,11 @@ def interactive_and_silent(scopes, auth_scheme, data, expected_token_type):
     _assert(result, expected_token_type)
 
 def test_broker_username_password(scopes, expected_token_type):
-    print("Testing broker username password flows by using labs account: 'fidlab@msidlab4.com', please provide the password.")
-    username = "fidlab@msidlab4.com"
-    password = input("Password:")
+    print("Testing broker username password flows by using accounts in local .env")
+    username = os.getenv("ENV_LAB4_ACCOUNT")
+    password = os.getenv("ENV_LAB4_ACCOUNT_PASSWORD")
+    assert(username!=None and len(username)>0)
+    assert(password!=None and len(password)>0)
     result = pca.acquire_token_by_username_password(username, password, scopes)
     _assert(result, expected_token_type)
     assert(result.get("token_source") == "broker")

--- a/tests/broker-test.py
+++ b/tests/broker-test.py
@@ -6,6 +6,7 @@ Each time a new PyMsalRuntime is going to be released,
 we can use this script to test it with a given version of MSAL Python.
 """
 import msal
+import getpass
 import os
 try:
     from dotenv import load_dotenv  # Use this only in local dev machine
@@ -54,10 +55,9 @@ def interactive_and_silent(scopes, auth_scheme, data, expected_token_type):
 
 def test_broker_username_password(scopes, expected_token_type):
     print("Testing broker username password flows by using accounts in local .env")
-    username = os.getenv("ENV_LAB4_ACCOUNT")
-    password = os.getenv("ENV_LAB4_ACCOUNT_PASSWORD")
-    assert(username!=None and len(username)>0)
-    assert(password!=None and len(password)>0)
+    username = os.getenv("BROKER_TEST_ACCOUNT") or input("Input test account for broker test: ")
+    password = os.getenv("BROKER_TEST_ACCOUNT_PASSWORD") or getpass.getpass("Input test account's password: ")
+    assert(username and password, "You need to provide a test account and its password")
     result = pca.acquire_token_by_username_password(username, password, scopes)
     _assert(result, expected_token_type)
     assert(result.get("token_source") == "broker")


### PR DESCRIPTION
Add a new broker ROPC test, and fix a broken test involved by [#712](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/712)

All tests passed.
![image](https://github.com/AzureAD/microsoft-authentication-library-for-python/assets/62267180/2678b4bb-9622-4338-a7c1-1af787f0f1c1)
