### PR TITLE
Support SNI via PFX

### DIFF
--- a/tests/test_cryptography.py
+++ b/tests/test_cryptography.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 import requests
 
 from msal.application import (
-    _str2bytes, _load_private_key_from_pem_str, _load_private_key_from_pfx_path)
+    _str2bytes, _load_private_key_from_pem_str, _parse_pfx)
 
 
 latest_cryptography_version = ET.fromstring(
@@ -48,7 +48,7 @@ class CryptographyTestCase(TestCase):
                 _load_private_key_from_pem_str(f.read(), passphrase_bytes)
             pfx = sibling("certificate-with-password.pfx")  # Created by:
                 # openssl pkcs12 -export -inkey test/certificate-with-password.pem -in tests/certificate-with-password.pem -out tests/certificate-with-password.pfx
-            _load_private_key_from_pfx_path(pfx, passphrase_bytes)
+            _parse_pfx(pfx, passphrase_bytes)
             self.assertEqual(0, len(encountered_warnings),
                 "Did cryptography deprecate the functions that we used?")
 


### PR DESCRIPTION
1. MSAL Python has long been supporting "Subject Name / Issuer authentication" (defined here `https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/60`) with this API:
   ```python
   ConfidentialClientApplication("client_id", client_credential={
       "public_certificate": "--- BEGIN CERTIFICATE --- ... ",
       ...
   }, ...)
   ```
   but MSAL Python did not use it in MSAL's own test environment.

2. [MSAL Python supports using client certificate in .pfx format since version 1.29](https://github.com/AzureAD/microsoft-authentication-library-for-python/releases/tag/1.29.0), and started using it in the test automation.

3. Recently, MSAL team's lab infrastructure requires "Subject Name / Issuer authentication" (defined here `https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/60`), otherwise the test automation will fail.

So, this PR adds SNI to the pfx code path, using this API.

```python
ConfidentialClientApplication("client_id", client_credential={
    "public_certificate": True,  # The cert will be read from .pfx
    "private_key_pfx_path": "/path/to/cert.pfx",
}, ...)
```

This new API will be released in MSAL Python 1.30.0. [Docs are staged here](https://msal-python.readthedocs.io/en/docs-staging/#msal.ClientApplication.params.client_credential).