### PR TITLE
MSAL 1.30.0

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -21,7 +21,7 @@ from .cloudshell import _is_running_in_cloud_shell
 
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.29.0"  # When releasing, also check and bump our dependencies's versions if needed
+__version__ = "1.30.0"  # When releasing, also check and bump our dependencies's versions if needed
 
 logger = logging.getLogger(__name__)
 _AUTHORITY_TYPE_CLOUDSHELL = "CLOUDSHELL"


### PR DESCRIPTION
## What's Changed
* New feature: Support Subject Name/Issuer authentication when using .pfx certificate file. Documentation available in one of the recent purple boxes [here](https://msal-python.readthedocs.io/en/latest/#msal.ClientApplication.params.client_credential). https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/718
* New feature: Automatically use SHA256 and PSS padding when using .pfx certificate on non-ADFS, non-OIDC authorities. https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/722
* New feature: Expose `refresh_on` (if any) to fresh or cached response, so that caller may choose to proactively call `acquire_token_silent()` early. https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/723
* Bugfix for token cache search. MSAL 1.27+ customers please upgrade to MSAL 1.30+. https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/717
