### PR TITLE
Broker refactoring, bugfix and test cases

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -26,6 +26,11 @@ __version__ = "1.30.0"  # When releasing, also check and bump our dependencies's
 logger = logging.getLogger(__name__)
 _AUTHORITY_TYPE_CLOUDSHELL = "CLOUDSHELL"
 
+def _init_broker(enable_pii_log):  # Make it a function to allow mocking
+    from . import broker  # Trigger Broker's initialization, lazily
+    if enable_pii_log:
+        broker._enable_pii_log()
+
 def extract_certs(public_cert_content):
     # Parses raw public certificate file contents and returns a list of strings
     # Usage: headers = {"x5c": extract_certs(open("my_cert.pem").read())}
@@ -655,9 +660,7 @@ class ClientApplication(object):
         if (self._enable_broker and not is_confidential_app
                 and not self.authority.is_adfs and not self.authority._is_b2c):
             try:
-                from . import broker  # Trigger Broker's initialization
-                if enable_pii_log:
-                    broker._enable_pii_log()
+                _init_broker(enable_pii_log)
             except RuntimeError:
                 self._enable_broker = False
                 logger.exception(


### PR DESCRIPTION
There is a recent offline discussion on when MSAL shall automatically be fallback to non-broker code path, even if the app opts in to use broker. For example, [ADFS and B2C scenarios are considered unsupported by broker (WAM)](https://learn.microsoft.com/en-us/entra/msal/dotnet/acquiring-tokens/desktop-mobile/wam#wam-limitations), but ideally MSAL shall not require app developers to opt in to broker conditionally, therefore, MSAL's DevEx (developer experience) is expected to automatically fall back to non-broker code path when appropriate.

MSAL Python did not previously have enough test cases for this, and there was even some discrepancy between the intention above and the actual behavior. This PR adds 6 test cases to inequivalently demonstrate the behaviors. Reviewers can focus on the test cases. There is also an open question on whether the `instance_discovery=False` scenario shall bypass broker.