### PR TITLE
Resource id adjustments

### DIFF
--- a/msal/managed_identity.py
+++ b/msal/managed_identity.py
@@ -46,8 +46,9 @@ class ManagedIdentity(UserDict):
 
     @classmethod
     def is_managed_identity(cls, unknown):
-        return isinstance(unknown, ManagedIdentity) or (
-            isinstance(unknown, dict) and cls.ID_TYPE in unknown)
+        return (isinstance(unknown, ManagedIdentity)
+            or cls.is_system_assigned(unknown)
+            or cls.is_user_assigned(unknown))
 
     @classmethod
     def is_system_assigned(cls, unknown):
@@ -217,6 +218,9 @@ class ManagedIdentityClient(object):
                 )
             token = client.acquire_token_for_client("resource")
         """
+        if not ManagedIdentity.is_managed_identity(managed_identity):
+            raise ManagedIdentityError(
+                f"Incorrect managed_identity: {managed_identity}")
         self._managed_identity = managed_identity
         self._http_client = _ThrottledHttpClient(
             # This class only throttles excess token acquisition requests.

--- a/tests/test_mi.py
+++ b/tests/test_mi.py
@@ -61,6 +61,14 @@ class ClientTestCase(unittest.TestCase):
             http_client=requests.Session(),
             )
 
+    def test_error_out_on_invalid_input(self):
+        with self.assertRaises(ManagedIdentityError):
+            ManagedIdentityClient({"foo": "bar"}, http_client=requests.Session())
+        with self.assertRaises(ManagedIdentityError):
+            ManagedIdentityClient(
+                {"ManagedIdentityIdType": "undefined", "Id": "foo"},
+                http_client=requests.Session())
+
     def assertCacheStatus(self, app):
         cache = app._token_cache._cache
         self.assertEqual(1, len(cache.get("AccessToken", [])), "Should have 1 AT")
@@ -240,6 +248,9 @@ class ArcTestCase(ClientTestCase):
     challenge = MinimalResponse(status_code=401, text="", headers={
         "WWW-Authenticate": "Basic realm=/tmp/foo",
         })
+
+    def test_error_out_on_invalid_input(self, mocked_stat):
+        return super(ArcTestCase, self).test_error_out_on_invalid_input()
 
     def test_happy_path(self, mocked_stat):
         expires_in = 1234


### PR DESCRIPTION
[This MSAL .Net issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4911) is applicable to MSAL Python, Java, Node.

This PR addresses that issue in MSAL Python, and may serve as pseudo code to represent what needs to be changed and tested.

After this PR, Resource ID will be sent as `mi_res_id` in App Service, and as `msi_res_id` in other flavors.

