### PR TITLE
Refactor to allow adding new field into cache key and/or content

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -249,8 +249,11 @@ class TokenCache(object):
                     "expires_on": str(now + expires_in),  # Same here
                     "extended_expires_on": str(now + ext_expires_in)  # Same here
                     }
-                if data.get("key_id"):  # It happens in SSH-cert or POP scenario
-                    at["key_id"] = data.get("key_id")
+                at.update({k: data[k] for k in data if k in {
+                    # Also store extra data which we explicitly allow
+                    # So that we won't accidentally store a user's password etc.
+                    "key_id",  # It happens in SSH-cert or POP scenario
+                }})
                 if "refresh_in" in response:
                     refresh_in = response["refresh_in"]  # It is an integer
                     at["refresh_on"] = str(now + refresh_in)  # Schema wants a string

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -340,6 +340,7 @@ class TestApplicationForRefreshInBehaviors(unittest.TestCase):
     account = {"home_account_id": "{}.{}".format(uid, utid)}
     rt = "this is a rt"
     client_id = "my_app"
+    soon = 60  # application.py considers tokens within 5 minutes as expired
 
     @classmethod
     def setUpClass(cls):  # Initialization at runtime, not interpret-time
@@ -414,7 +415,8 @@ class TestApplicationForRefreshInBehaviors(unittest.TestCase):
 
     def test_expired_token_and_unavailable_aad_should_return_error(self):
         # a.k.a. Attempt refresh expired token when AAD unavailable
-        self.populate_cache(access_token="expired at", expires_in=-1, refresh_in=-900)
+        self.populate_cache(
+            access_token="expired at", expires_in=self.soon, refresh_in=-900)
         error = "something went wrong"
         def mock_post(url, headers=None, *args, **kwargs):
             self.assertEqual("4|84,3|", (headers or {}).get(CLIENT_CURRENT_TELEMETRY))
@@ -425,7 +427,8 @@ class TestApplicationForRefreshInBehaviors(unittest.TestCase):
 
     def test_expired_token_and_available_aad_should_return_new_token(self):
         # a.k.a. Attempt refresh expired token when AAD available
-        self.populate_cache(access_token="expired at", expires_in=-1, refresh_in=-900)
+        self.populate_cache(
+            access_token="expired at", expires_in=self.soon, refresh_in=-900)
         new_access_token = "new AT"
         new_refresh_in = 123
         def mock_post(url, headers=None, *args, **kwargs):


### PR DESCRIPTION
Previously the token cache was based on an internal schema. Over the years, we have hardly changed the token's value to store new fields, and we never changed the token's key format for fear of potential token cache miss.

This PR refactors the token cache implementation. After this PR, future addition of new fields will be as simple as two steps:

1. [Update this inline allow-list to ***store***](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/751/files#diff-57d03d4a73bcfebc3e50086e1cdaa27c9c43e862606e3d45abf4f6c5e61d98d8R273) a new field into the token's entry in the cache.
2. [Update this parameter](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/751/files#diff-57d03d4a73bcfebc3e50086e1cdaa27c9c43e862606e3d45abf4f6c5e61d98d8R63) AND [that inline allow-list](https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/751/files#diff-57d03d4a73bcfebc3e50086e1cdaa27c9c43e862606e3d45abf4f6c5e61d98d8R72) to use the new field as part of the cache key.

This PR is a pure refactoring which does NOT actually change the token key behavior.
