### PR TITLE
Pass Sku and Ver to MsalRuntime

### DIFF
--- a/msal/__init__.py
+++ b/msal/__init__.py
@@ -26,12 +26,12 @@
 #------------------------------------------------------------------------------
 
 from .application import (
-    __version__,
     ClientApplication,
     ConfidentialClientApplication,
     PublicClientApplication,
     )
 from .oauth2cli.oidc import Prompt, IdTokenError
+from .sku import __version__
 from .token_cache import TokenCache, SerializableTokenCache
 from .auth_scheme import PopAuthScheme
 from .managed_identity import (

--- a/msal/application.py
+++ b/msal/application.py
@@ -19,10 +19,9 @@ import msal.telemetry
 from .region import _detect_region
 from .throttled_http_client import ThrottledHttpClient
 from .cloudshell import _is_running_in_cloud_shell
+from .sku import SKU, __version__
 
 
-# The __init__.py will import this. Not the other way around.
-__version__ = "1.31.1"  # When releasing, also check and bump our dependencies's versions if needed
 
 logger = logging.getLogger(__name__)
 _AUTHORITY_TYPE_CLOUDSHELL = "CLOUDSHELL"
@@ -770,7 +769,7 @@ The reserved list: {}""".format(list(scope_set), list(reserved_scope)))
         client_assertion = None
         client_assertion_type = None
         default_headers = {
-            "x-client-sku": "MSAL.Python", "x-client-ver": __version__,
+            "x-client-sku": SKU, "x-client-ver": __version__,
             "x-client-os": sys.platform,
             "x-ms-lib-capability": "retry-after, h429",
         }

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -9,10 +9,7 @@ import uuid
 
 from .sku import __version__, SKU
 
-
 logger = logging.getLogger(__name__)
-
-
 try:
     import pymsalruntime  # Its API description is available in site-packages/pymsalruntime/PyMsalRuntime.pyi
     pymsalruntime.register_logging_callback(lambda message, level: {  # New in pymsalruntime 0.7

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -9,6 +9,10 @@ import uuid
 
 
 logger = logging.getLogger(__name__)
+
+from .application import (
+    __version__)
+
 try:
     import pymsalruntime  # Its API description is available in site-packages/pymsalruntime/PyMsalRuntime.pyi
     pymsalruntime.register_logging_callback(lambda message, level: {  # New in pymsalruntime 0.7
@@ -135,6 +139,9 @@ def _get_new_correlation_id():
 def _enable_msa_pt(params):
     params.set_additional_parameter("msal_request_type", "consumer_passthrough")  # PyMsalRuntime 0.8+
 
+def _pass_client_sku(params):
+    params.set_additional_parameter("msal_client_sku", "MSAL.Python")  
+    params.set_additional_parameter("msal_client_ver", __version__) 
 
 def _signin_silently(
         authority, client_id, scopes, correlation_id=None, claims=None,
@@ -143,6 +150,7 @@ def _signin_silently(
         **kwargs):
     params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
     params.set_requested_scopes(scopes)
+    _pass_client_sku(params)
     if claims:
         params.set_decoded_claims(claims)
     if auth_scheme:
@@ -176,6 +184,7 @@ def _signin_interactively(
         **kwargs):
     params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
     params.set_requested_scopes(scopes)
+    _pass_client_sku(params)
     params.set_redirect_uri(
         _redirect_uri_on_mac if sys.platform == "darwin" else
         "https://login.microsoftonline.com/common/oauth2/nativeclient"
@@ -232,6 +241,7 @@ def _acquire_token_silently(
         return
     params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
     params.set_requested_scopes(scopes)
+    _pass_client_sku(params)
     if claims:
         params.set_decoded_claims(claims)
     if auth_scheme:

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -7,11 +7,11 @@ import sys
 import time
 import uuid
 
+from .application import __version__
+
 
 logger = logging.getLogger(__name__)
 
-from .application import (
-    __version__)
 
 try:
     import pymsalruntime  # Its API description is available in site-packages/pymsalruntime/PyMsalRuntime.pyi
@@ -139,18 +139,19 @@ def _get_new_correlation_id():
 def _enable_msa_pt(params):
     params.set_additional_parameter("msal_request_type", "consumer_passthrough")  # PyMsalRuntime 0.8+
 
-def _pass_client_sku(params):
-    params.set_additional_parameter("msal_client_sku", "MSAL.Python")  
-    params.set_additional_parameter("msal_client_ver", __version__) 
+def _build_msal_runtime_auth_params(client_id, authority):
+    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params.set_additional_parameter("msal_client_sku", "MSAL.Python")
+    params.set_additional_parameter("msal_client_ver", __version__)
+    return params
 
 def _signin_silently(
         authority, client_id, scopes, correlation_id=None, claims=None,
         enable_msa_pt=False,
         auth_scheme=None,
         **kwargs):
-    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params = _build_msal_runtime_auth_params(client_id, authority)
     params.set_requested_scopes(scopes)
-    _pass_client_sku(params)
     if claims:
         params.set_decoded_claims(claims)
     if auth_scheme:
@@ -182,9 +183,8 @@ def _signin_interactively(
         enable_msa_pt=False,
         auth_scheme=None,
         **kwargs):
-    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params = _build_msal_runtime_auth_params(client_id, authority)
     params.set_requested_scopes(scopes)
-    _pass_client_sku(params)
     params.set_redirect_uri(
         _redirect_uri_on_mac if sys.platform == "darwin" else
         "https://login.microsoftonline.com/common/oauth2/nativeclient"
@@ -239,9 +239,8 @@ def _acquire_token_silently(
     account = _read_account_by_id(account_id, correlation_id)
     if account is None:
         return
-    params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
+    params = _build_msal_runtime_auth_params(client_id, authority)
     params.set_requested_scopes(scopes)
-    _pass_client_sku(params)
     if claims:
         params.set_decoded_claims(claims)
     if auth_scheme:

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -7,7 +7,7 @@ import sys
 import time
 import uuid
 
-from .application import __version__
+from .sku import __version__, SKU
 
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ def _enable_msa_pt(params):
 
 def _build_msal_runtime_auth_params(client_id, authority):
     params = pymsalruntime.MSALRuntimeAuthParameters(client_id, authority)
-    params.set_additional_parameter("msal_client_sku", "MSAL.Python")
+    params.set_additional_parameter("msal_client_sku", SKU)
     params.set_additional_parameter("msal_client_ver", __version__)
     return params
 

--- a/msal/sku.py
+++ b/msal/sku.py
@@ -1,0 +1,6 @@
+"""This module is from where we recieve the client sku name and version.
+"""
+
+# The __init__.py will import this. Not the other way around.
+__version__ = "1.31.1" # When releasing, also check and bump our dependencies's versions if needed
+SKU = "MSAL.Python"


### PR DESCRIPTION
Passes Msal.py sku and version to Msalcpp during runtime flows to be used in x-client-xtra-sku header in order to support ESTS telemetry

[AB#3138694](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3138694)