### PR TITLE
Try to suppress another verify=False

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1323,7 +1323,7 @@ class PopTestCase(LabBasedTestCase):
         # We skip it here because this test case has not yet initialize self.app
         # assert self.app.is_pop_supported()
         api_endpoint = "https://20.190.132.47/beta/me"
-        resp = requests.get(api_endpoint, verify=False)
+        resp = requests.get(api_endpoint, verify=False)  # @suppress py/bandit/requests-ssl-verify-disabled
         self.assertEqual(resp.status_code, 401, "Initial call should end with an http 401 error")
         result = self._get_shr_pop(**dict(
             self.get_lab_user(usertype="cloud"),  # This is generally not the current laptop's default AAD account


### PR DESCRIPTION
We already suppressed [a CodeQL issue reported in Liquid](https://liquid.microsoft.com/codeql/issues/fe33571c-2e2c-436e-a374-f7ace940389e), yet the alarm comes back again. Upon further investigation, we found another similar occurrence that was not reported by Liquid, but likely the missing fix that we need. Suppress it in this PR, and see how that goes.

This PR is expected to fix #787