### PR TITLE
MSAL Python 1.32.0

### DIFF
--- a/msal/sku.py
+++ b/msal/sku.py
@@ -2,5 +2,5 @@
 """
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.31.1" # When releasing, also check and bump our dependencies's versions if needed
+__version__ = "1.32.0"
 SKU = "MSAL.Python"


### PR DESCRIPTION
Plan to ship MSAL Python 1.32.0 soon. The release note will roughly contain the following content.

* New feature: Supports dSTS by `ClientApplication(..., authority="https://...example.com/dstsv2/...")` (#767, #772)
* New feature: Start to support POD Identity, configured by env var `AZURE_POD_IDENTITY_AUTHORITY_HOST=http://ip:port` (#794, #795)
* Bugfix: Support resource with the format of "GUID/.default" when running inside Cloud Shell. (#784, #785)
* Other internal refactoring (#751, #786, [...](https://github.com/AzureAD/microsoft-authentication-library-for-python/compare/1.31.1...release-1.32.0))

