### PR TITLE
Update deprecated TokenCache API usage

### DIFF
--- a/msal/managed_identity.py
+++ b/msal/managed_identity.py
@@ -298,7 +298,7 @@ class ManagedIdentityClient(object):
         now = time.time()
         if True:  # Attempt cache search even if receiving claims_challenge,
                   # because we want to locate the existing token (if any) and refresh it
-            matches = self._token_cache.find(
+            matches = self._token_cache.search(
                 self._token_cache.CredentialType.ACCESS_TOKEN,
                 target=[resource],
                 query=dict(

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -2,6 +2,7 @@ import logging
 import base64
 import json
 import time
+import warnings
 
 from msal.token_cache import TokenCache, SerializableTokenCache
 from tests import unittest
@@ -83,10 +84,11 @@ class TokenCacheTestCase(unittest.TestCase):
             }
         self.assertEqual(access_token_entry, self.cache._cache["AccessToken"].get(
             self.at_key_maker(**access_token_entry)))
-        self.assertIn(
-            access_token_entry,
-            self.cache.find(self.cache.CredentialType.ACCESS_TOKEN, now=now),
-            "find(..., query=None) should not crash, even though MSAL does not use it")
+        with warnings.catch_warnings():
+            self.assertIn(
+                access_token_entry,
+                self.cache.find(self.cache.CredentialType.ACCESS_TOKEN, now=now),
+                "find(..., query=None) should not crash, even though MSAL does not use it")
         self.assertEqual(
             {
                 'client_id': 'my_client_id',


### PR DESCRIPTION
There was a place in `ManagedIdentityClient` where the `TokenCache.find` method was still being used, leading to some deprecation warnings being printed. This updates that to use `TokenCache.search`.