### PR TITLE
Improve test cases to test header-less response

### DIFF
--- a/tests/http_client.py
+++ b/tests/http_client.py
@@ -28,7 +28,12 @@ class MinimalResponse(object):  # Not for production use
     def __init__(self, requests_resp=None, status_code=None, text=None, headers=None):
         self.status_code = status_code or requests_resp.status_code
         self.text = text if text is not None else requests_resp.text
-        self.headers = {} if headers is None else headers
+        if headers:
+            # Early versions of MSAL did not require http response to contain headers.
+            # As of April 2025, some Azure Identity code paths still yield response without headers.
+            # Here we mimic the behavior of header-less response by default,
+            # so that test cases can cover header-less response scenarios.
+            self.headers = headers
         self._raw_resp = requests_resp
 
     def raise_for_status(self):

--- a/tests/test_throttled_http_client.py
+++ b/tests/test_throttled_http_client.py
@@ -50,18 +50,6 @@ class DummyHttpClient(object):
         raise CloseMethodCalled("Not used by MSAL, but our customers may use it")
 
 
-class DummyHttpClientWithoutResponseHeaders(DummyHttpClient):
-    def post(self, url, params=None, data=None, headers=None, **kwargs):
-        response = super().post(url, params, data, headers, **kwargs)
-        del response.headers  # Early versions of MSAL did not require http client to return headers
-        return response
-
-    def get(self, url, params=None, headers=None, **kwargs):
-        response = super().get(url, params, headers, **kwargs)
-        del response.headers  # Early versions of MSAL did not require http client to return headers
-        return response
-
-
 class CloseMethodCalled(Exception):
     pass
 
@@ -99,9 +87,14 @@ class ThrottledHttpClientBaseTestCase(unittest.TestCase):
         self.assertCleanPickle(response)
 
     def test_throttled_http_client_base_response_should_tolerate_headerless_response(self):
-        http_client = ThrottledHttpClientBase(DummyHttpClientWithoutResponseHeaders(
-            status_code=200, response_text="foo"))
-        response = http_client.post("https://example.com")
+        # MSAL Python 1.32.1 had a regression that caused it to require headers in the response.
+        # This was fixed in 1.32.2
+        # https://github.com/AzureAD/microsoft-authentication-library-for-python/compare/1.32.1...1.32.2
+        # This test case is to ensure that we can tolerate headerless response.
+        http_client = DummyHttpClient(status_code=200, response_text="foo")
+        raw_response = http_client.post("https://example.com")
+        self.assertFalse(hasattr(raw_response, "headers"), "Should not contain headers")
+        response = ThrottledHttpClientBase(http_client).post("https://example.com")
         self.assertEqual(response.text, "foo", "Should return the same response text")
 
     def test_throttled_http_client_base_response_should_not_contain_signature(self):


### PR DESCRIPTION
MSAL has long been allowing callers to specify their own http client. Early versions of MSAL Python did not require that http client's response to contain headers. This PR changes the test helper to mimic a header-less response by default, so that our existing test cases will automatically cover header-less response scenarios. This can help preventing regression.

P.S.
Issue #817 was created in an aftermath of such a regression. This PR precisely covers those scenarios; therefore, it can resolve #817.
(End-to-end tests, while being useful in their own right, would not be enough to guard against this kind of "header-less response regression", because real e2e requests are typically sent with real http clients that always contain headers.)

Lastly, note that this PR changes only a couple of files in the "./tests" directory. It does not alter any existing MSAL behavior. It is a low-risk PR.