### PR TITLE
Upgrade dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     # And we will use the cryptography (X+3).0.0 as the upper bound,
     # based on their latest deprecation policy
     # https://cryptography.io/en/latest/api-stability/#deprecation
-    cryptography>=2.5,<47
+    cryptography>=2.5,<48
 
 
 [options.extras_require]


### PR DESCRIPTION
One of our dependency, [the Cryptography library, shipped a new version during weekend](https://pypi.org/project/cryptography/#history).

We pinned the dependency version but also have a test case to detect its release and remind us to manually test MSAL with latest dependency. The manual test was performed and successful. So, this PR bumps the dependency's upper bound accordingly.