### PR TITLE
Use lowercase environment value during searching

### DIFF
--- a/msal/token_cache.py
+++ b/msal/token_cache.py
@@ -126,7 +126,13 @@ class TokenCache(object):
 
     @staticmethod
     def _is_matching(entry: dict, query: dict, target_set: set = None) -> bool:
-        return is_subdict_of(query or {}, entry) and (
+        query_with_lowercase_environment = {
+            # __add() canonicalized entry's environment value to lower case,
+            # so we do the same here.
+            k: v.lower() if k == "environment" and isinstance(v, str) else v
+            for k, v in query.items()
+        } if query else {}
+        return is_subdict_of(query_with_lowercase_environment, entry) and (
             target_set <= set(entry.get("target", "").split())
             if target_set else True)
 

--- a/tests/test_mi.py
+++ b/tests/test_mi.py
@@ -190,6 +190,10 @@ class VmTestCase(ClientTestCase):
             headers={'Metadata': 'true'},
             )
 
+    @patch("msal.managed_identity.socket.getfqdn", new=lambda: "MixedCaseHostName")
+    def test_happy_path_of_windows_vm(self):
+        self.test_happy_path_of_vm()
+
     @patch.dict(os.environ, {"AZURE_POD_IDENTITY_AUTHORITY_HOST": "http://localhost:1234//"})
     def test_happy_path_of_pod_identity(self):
         self._test_happy_path().assert_called_with(


### PR DESCRIPTION
Context: The "environment" field in the token cache contains an authority's domain name, which is stored as lowercase in cache. We did that right. But we noticed that when performing a search in the token cache, we were not converting the "environment" field to lowercase. This is usually not a problem, because the domain name is typically in lowercase. And no customer reported any issue. However, recently    when we are running Managed Identity test cases on Windows, we found out that the domain name placeholder that we use, turns out to be mixed case on Windows, such as "CPC-raylu-UB85C". This would cause cache miss when running the Managed Identity client on a Windows machine.

This PR improves the token cache search/match logic to always search environment by lowercase.