### PR TITLE
Add OIDC issuer validation

### DIFF
--- a/msal/authority.py
+++ b/msal/authority.py
@@ -108,6 +108,9 @@ class Authority(object):
                 "The issuer '{iss}' does not match the authority '{auth}' or a known pattern. "
                 "When using the 'oidc_authority' parameter in ClientApplication, the authority "
                 "will be validated against the issuer from {auth}/.well-known/openid-configuration ."
+                "If using a known Entra authority (e.g. login.microsoftonline.com) the "
+                "'authority' parameter should be used instead of 'oidc_authority'. "
+                ""
             ).format(iss=self._issuer, auth=oidc_authority_url))
     def _initialize_oidc_authority(self, oidc_authority_url):
         authority, self.instance, tenant = canonicalize(oidc_authority_url)
@@ -189,7 +192,6 @@ class Authority(object):
 
             An issuer is valid if one of the following is true:
             - It exactly matches the authority URL
-            - It has a known Microsoft host (e.g., login.microsoftonline.com)
             - It has the same scheme and host as the authority (path can be different)
             - For CIAM, the issuer follows the pattern of {tenant}.ciamlogin.com (tenant comes from the authority)
             """
@@ -200,10 +202,6 @@ class Authority(object):
         issuer = urlparse(self._issuer) if self._issuer else None
         if not issuer:
             return False
-
-        # Check if issuer has a known Microsoft host
-        if issuer.hostname in WELL_KNOWN_AUTHORITY_HOSTS:
-            return True
 
         # Check if issuer has the same scheme and host as the authority
         authority = urlparse(self._oidc_authority_url)

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -39,6 +39,9 @@ TRUSTED_ISSUER_HOSTS = frozenset([
     "login.microsoftonline.us",
     "login.usgovcloudapi.net",
     "login-us.microsoftonline.com",
+    "https://login.sovcloud-identity.fr", # AzureBleu
+    "https://login.sovcloud-identity.de", # AzureDelos
+    "https://login.sovcloud-identity.sg", # AzureGovSG
 ])
 
 WELL_KNOWN_B2C_HOSTS = [
@@ -215,7 +218,7 @@ class Authority(object):
         - It has the same scheme and host as the authority (path can be different)
         - The issuer host is a well-known Microsoft authority host
         - The issuer host is a regional variant of a well-known host (e.g., westus2.login.microsoft.com)
-        - For CIAM, the issuer follows the pattern of {tenant}.ciamlogin.com
+        - For CIAM, hosts that end with well-known B2C hosts (e.g., tenant.b2clogin.com) are accepted as valid issuers
         """
         if not self._issuer or not self._oidc_authority_url:
             return False
@@ -240,25 +243,25 @@ class Authority(object):
         dot_index = issuer_host.find(".")
         if dot_index > 0:
             potential_base = issuer_host[dot_index + 1:]
-            if potential_base in TRUSTED_ISSUER_HOSTS and "." not in issuer_host[:dot_index]:
-                return True
+            if "." not in issuer_host[:dot_index]:
+                # 3a: Base host is a trusted Microsoft host
+                if potential_base in TRUSTED_ISSUER_HOSTS:
+                    return True
+                # 3b: Issuer has a region prefix on the authority host
+                #     e.g. issuer=us.someweb.com, authority=someweb.com
+                authority_host = authority_parsed.hostname.lower() if authority_parsed.hostname else ""
+                if potential_base == authority_host:
+                    return True
 
         # Case 4: Same scheme and host (path can differ)
         if (authority_parsed.scheme == issuer_parsed.scheme and 
             authority_parsed.netloc == issuer_parsed.netloc):
             return True
+        
+        # Case 5: Check if issuer host ends with any well-known B2C host (e.g., tenant.b2clogin.com)
+        if any(issuer_host.endswith(h) for h in WELL_KNOWN_B2C_HOSTS):
+            return True
 
-        # Case 5: CIAM scenario - issuer follows pattern {tenant}.ciamlogin.com
-        if issuer_host.endswith(_CIAM_DOMAIN_SUFFIX):
-            authority_host = authority_parsed.hostname.lower() if authority_parsed.hostname else ""
-            if authority_host.endswith(_CIAM_DOMAIN_SUFFIX):
-                tenant = authority_host[:-len(_CIAM_DOMAIN_SUFFIX)]
-            else:
-                parts = authority_parsed.path.split('/')
-                tenant = parts[1] if len(parts) >= 2 and parts[1] else None
-            
-            if tenant and issuer_host == tenant + _CIAM_DOMAIN_SUFFIX:
-                return True
         return False
 
 def canonicalize(authority_or_auth_endpoint):

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -237,9 +237,12 @@ class Authority(object):
 
         # Case 3: Regional variant check - O(1) lookup
         # e.g., westus2.login.microsoft.com -> extract "login.microsoft.com"
-        if any(issuer_host.endswith("." + trusted) for trusted in TRUSTED_ISSUER_HOSTS):
-            return True
-        
+        dot_index = issuer_host.find(".")
+        if dot_index > 0:
+            potential_base = issuer_host[dot_index + 1:]
+            if potential_base in TRUSTED_ISSUER_HOSTS and "." not in issuer_host[:dot_index]:
+                return True
+
         # Case 4: Same scheme and host (path can differ)
         if (authority_parsed.scheme == issuer_parsed.scheme and 
             authority_parsed.netloc == issuer_parsed.netloc):

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -237,12 +237,9 @@ class Authority(object):
 
         # Case 3: Regional variant check - O(1) lookup
         # e.g., westus2.login.microsoft.com -> extract "login.microsoft.com"
-        dot_index = issuer_host.find(".")
-        if dot_index > 0:
-            potential_base = issuer_host[dot_index + 1:]
-            if potential_base in TRUSTED_ISSUER_HOSTS and "." not in issuer_host[:dot_index]:
-                return True
-
+        if any(issuer_host.endswith("." + trusted) for trusted in TRUSTED_ISSUER_HOSTS):
+            return True
+        
         # Case 4: Same scheme and host (path can differ)
         if (authority_parsed.scheme == issuer_parsed.scheme and 
             authority_parsed.netloc == issuer_parsed.netloc):

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -21,6 +21,26 @@ WELL_KNOWN_AUTHORITY_HOSTS = set([
     'login-us.microsoftonline.com',
     AZURE_US_GOVERNMENT,
     ])
+
+# Trusted issuer hosts for OIDC issuer validation
+# Includes all well-known Microsoft identity provider hosts and national clouds
+TRUSTED_ISSUER_HOSTS = frozenset([
+    # Global/Public cloud
+    "login.microsoftonline.com",
+    "login.microsoft.com",
+    "login.windows.net",
+    "sts.windows.net",
+    # China cloud
+    "login.chinacloudapi.cn",
+    "login.partner.microsoftonline.cn",
+    # Germany cloud (legacy)
+    "login.microsoftonline.de",
+    # US Government clouds
+    "login.microsoftonline.us",
+    "login.usgovcloudapi.net",
+    "login-us.microsoftonline.com",
+])
+
 WELL_KNOWN_B2C_HOSTS = [
     "b2clogin.com",
     "b2clogin.cn",
@@ -186,47 +206,59 @@ class Authority(object):
             self.__class__._domains_without_user_realm_discovery.add(self.instance)
         return {}  # This can guide the caller to fall back normal ROPC flow
 
-    def has_valid_issuer(self) -> bool:
+    def has_valid_issuer(self):
         """
-            Returns True if the issuer from OIDC discovery is valid for this authority.
+        Returns True if the issuer from OIDC discovery is valid for this authority.
 
-            An issuer is valid if one of the following is true:
-            - It exactly matches the authority URL
-            - It has the same scheme and host as the authority (path can be different)
-            - For CIAM, the issuer follows the pattern of {tenant}.ciamlogin.com (tenant comes from the authority)
-            """
-        if self._oidc_authority_url == self._issuer:
-            # The issuer matches the authority URL exactly
-            return True
-
-        issuer = urlparse(self._issuer) if self._issuer else None
-        if not issuer:
+        An issuer is valid if one of the following is true:
+        - It exactly matches the authority URL (with/without trailing slash)
+        - It has the same scheme and host as the authority (path can be different)
+        - The issuer host is a well-known Microsoft authority host
+        - The issuer host is a regional variant of a well-known host (e.g., westus2.login.microsoft.com)
+        - For CIAM, the issuer follows the pattern of {tenant}.ciamlogin.com
+        """
+        if not self._issuer or not self._oidc_authority_url:
             return False
 
-        # Check if issuer has the same scheme and host as the authority
-        authority = urlparse(self._oidc_authority_url)
-        if authority.scheme == issuer.scheme and authority.netloc == issuer.netloc:
+        # Case 1: Exact match (most common case, normalized for trailing slashes)
+        if self._issuer.rstrip("/") == self._oidc_authority_url.rstrip("/"):
             return True
 
-        # Check CIAM scenario: issuer follows the pattern {tenant}.ciamlogin.com
-        # Extract tenant from authority URL - could be in the host or path
-        tenant = None
-        if authority.hostname.endswith(_CIAM_DOMAIN_SUFFIX):
-            # Normal CIAM host: {tenant}.ciamlogin.com
-            tenant = authority.hostname.rsplit(_CIAM_DOMAIN_SUFFIX, 1)[0]
-        else:
-            # Custom CIAM host: extract tenant from path
-            parts = authority.path.split('/')
-            if len(parts) >= 2 and parts[1]:
-                tenant = parts[1]  # First path segment after the initial '/'
+        issuer_parsed = urlparse(self._issuer)
+        authority_parsed = urlparse(self._oidc_authority_url)
+        issuer_host = issuer_parsed.hostname.lower() if issuer_parsed.hostname else None
 
-        if tenant and issuer.hostname.endswith(_CIAM_DOMAIN_SUFFIX):
-            # Check if issuer follows the pattern {tenant}.ciamlogin.com
-            expected_issuer_host = f"{tenant}{_CIAM_DOMAIN_SUFFIX}"
-            if issuer.hostname == expected_issuer_host:
+        if not issuer_host:
+            return False
+        
+        # Case 2: Issuer is from a trusted Microsoft host - O(1) lookup
+        if issuer_host in TRUSTED_ISSUER_HOSTS:
+            return True
+
+        # Case 3: Regional variant check - O(1) lookup
+        # e.g., westus2.login.microsoft.com -> extract "login.microsoft.com"
+        dot_index = issuer_host.find(".")
+        if dot_index > 0:
+            potential_base = issuer_host[dot_index + 1:]
+            if potential_base in TRUSTED_ISSUER_HOSTS and "." not in issuer_host[:dot_index]:
                 return True
 
-        # None of the conditions matched
+        # Case 4: Same scheme and host (path can differ)
+        if (authority_parsed.scheme == issuer_parsed.scheme and 
+            authority_parsed.netloc == issuer_parsed.netloc):
+            return True
+
+        # Case 5: CIAM scenario - issuer follows pattern {tenant}.ciamlogin.com
+        if issuer_host.endswith(_CIAM_DOMAIN_SUFFIX):
+            authority_host = authority_parsed.hostname.lower() if authority_parsed.hostname else ""
+            if authority_host.endswith(_CIAM_DOMAIN_SUFFIX):
+                tenant = authority_host[:-len(_CIAM_DOMAIN_SUFFIX)]
+            else:
+                parts = authority_parsed.path.split('/')
+                tenant = parts[1] if len(parts) >= 2 and parts[1] else None
+            
+            if tenant and issuer_host == tenant + _CIAM_DOMAIN_SUFFIX:
+                return True
         return False
 
 def canonicalize(authority_or_auth_endpoint):

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -114,7 +114,6 @@ class Authority(object):
                 .format(authority_url)
                 ) + " Also please double check your tenant name or GUID is correct."
             raise ValueError(error_message)
-        openid_config.pop("issuer", None)  # Not used in MSAL.py, so remove it therefore no need to validate it
         logger.debug(
             'openid_config("%s") = %s', tenant_discovery_endpoint, openid_config)
         self._issuer = openid_config.get('issuer')

--- a/msal/authority.py
+++ b/msal/authority.py
@@ -67,6 +67,7 @@ class Authority(object):
             performed.
         """
         self._http_client = http_client
+        self._oidc_authority_url = oidc_authority_url
         if oidc_authority_url:
             logger.debug("Initializing with OIDC authority: %s", oidc_authority_url)
             tenant_discovery_endpoint = self._initialize_oidc_authority(
@@ -95,11 +96,19 @@ class Authority(object):
             raise ValueError(error_message)
         logger.debug(
             'openid_config("%s") = %s', tenant_discovery_endpoint, openid_config)
+        self._issuer = openid_config.get('issuer')
         self.authorization_endpoint = openid_config['authorization_endpoint']
         self.token_endpoint = openid_config['token_endpoint']
         self.device_authorization_endpoint = openid_config.get('device_authorization_endpoint')
         _, _, self.tenant = canonicalize(self.token_endpoint)  # Usually a GUID
 
+        # Validate the issuer if using OIDC authority
+        if self._oidc_authority_url and not self.has_valid_issuer():
+            raise ValueError((
+                "The issuer '{iss}' does not match the authority '{auth}' or a known pattern. "
+                "When using the 'oidc_authority' parameter in ClientApplication, the authority "
+                "will be validated against the issuer from {auth}/.well-known/openid-configuration ."
+            ).format(iss=self._issuer, auth=oidc_authority_url))
     def _initialize_oidc_authority(self, oidc_authority_url):
         authority, self.instance, tenant = canonicalize(oidc_authority_url)
         self.is_adfs = tenant.lower() == 'adfs'  # As a convention
@@ -174,6 +183,53 @@ class Authority(object):
             self.__class__._domains_without_user_realm_discovery.add(self.instance)
         return {}  # This can guide the caller to fall back normal ROPC flow
 
+    def has_valid_issuer(self) -> bool:
+        """
+            Returns True if the issuer from OIDC discovery is valid for this authority.
+
+            An issuer is valid if one of the following is true:
+            - It exactly matches the authority URL
+            - It has a known Microsoft host (e.g., login.microsoftonline.com)
+            - It has the same scheme and host as the authority (path can be different)
+            - For CIAM, the issuer follows the pattern of {tenant}.ciamlogin.com (tenant comes from the authority)
+            """
+        if self._oidc_authority_url == self._issuer:
+            # The issuer matches the authority URL exactly
+            return True
+
+        issuer = urlparse(self._issuer) if self._issuer else None
+        if not issuer:
+            return False
+
+        # Check if issuer has a known Microsoft host
+        if issuer.hostname in WELL_KNOWN_AUTHORITY_HOSTS:
+            return True
+
+        # Check if issuer has the same scheme and host as the authority
+        authority = urlparse(self._oidc_authority_url)
+        if authority.scheme == issuer.scheme and authority.netloc == issuer.netloc:
+            return True
+
+        # Check CIAM scenario: issuer follows the pattern {tenant}.ciamlogin.com
+        # Extract tenant from authority URL - could be in the host or path
+        tenant = None
+        if authority.hostname.endswith(_CIAM_DOMAIN_SUFFIX):
+            # Normal CIAM host: {tenant}.ciamlogin.com
+            tenant = authority.hostname.rsplit(_CIAM_DOMAIN_SUFFIX, 1)[0]
+        else:
+            # Custom CIAM host: extract tenant from path
+            parts = authority.path.split('/')
+            if len(parts) >= 2 and parts[1]:
+                tenant = parts[1]  # First path segment after the initial '/'
+
+        if tenant and issuer.hostname.endswith(_CIAM_DOMAIN_SUFFIX):
+            # Check if issuer follows the pattern {tenant}.ciamlogin.com
+            expected_issuer_host = f"{tenant}{_CIAM_DOMAIN_SUFFIX}"
+            if issuer.hostname == expected_issuer_host:
+                return True
+
+        # None of the conditions matched
+        return False
 
 def canonicalize(authority_or_auth_endpoint):
     # Returns (url_parsed_result, hostname_in_lowercase, tenant)
@@ -222,4 +278,3 @@ def tenant_discovery(tenant_discovery_endpoint, http_client, **kwargs):
     resp.raise_for_status()
     raise RuntimeError(  # A fallback here, in case resp.raise_for_status() is no-op
         "Unable to complete OIDC Discovery: %d, %s" % (resp.status_code, resp.text))
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     # And we will use the cryptography (X+3).0.0 as the upper bound,
     # based on their latest deprecation policy
     # https://cryptography.io/en/latest/api-stability/#deprecation
-    cryptography>=2.5,<48
+    cryptography>=2.5,<49
 
 
 [options.extras_require]

--- a/tests/simulator.py
+++ b/tests/simulator.py
@@ -31,6 +31,7 @@ class ClientCredentialGrantSimulator(object):
         with patch.object(msal.authority, "tenant_discovery", return_value={
             "authorization_endpoint": "https://contoso.com/placeholder",
             "token_endpoint": "https://contoso.com/placeholder",
+            "issuer": "https://contoso.com/placeholder",
         }) as _:  # Otherwise it would fail on OIDC discovery
             self.apps = [  # In MSAL Python, each CCA binds to one tenant only
                 msal.ConfidentialClientApplication(

--- a/tests/test_account_source.py
+++ b/tests/test_account_source.py
@@ -26,6 +26,7 @@ def _mock_post(url, headers=None, *args, **kwargs):
 @patch.object(msal.authority, "tenant_discovery", return_value={
     "authorization_endpoint": "https://contoso.com/placeholder",
     "token_endpoint": "https://contoso.com/placeholder",
+    "issuer": "https://contoso.com/placeholder",
 })  # Otherwise it would fail on OIDC discovery
 class TestAccountSourceBehavior(unittest.TestCase):
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -24,6 +24,7 @@ _OIDC_DISCOVERY = "msal.authority.tenant_discovery"
 _OIDC_DISCOVERY_MOCK = Mock(return_value={
     "authorization_endpoint": "https://contoso.com/placeholder",
     "token_endpoint": "https://contoso.com/placeholder",
+    "issuer": "https://contoso.com/tenant",
 })
 
 
@@ -690,6 +691,7 @@ class TestClientCredentialGrant(unittest.TestCase):
     @patch(_OIDC_DISCOVERY, new=Mock(return_value={
         "authorization_endpoint": "https://contoso.com/common",
         "token_endpoint": "https://contoso.com/common",
+        "issuer": "https://contoso.com/common",
         }))
     def test_common_authority_should_emit_warning(self):
         self._test_certain_authority_should_emit_warning(
@@ -698,6 +700,7 @@ class TestClientCredentialGrant(unittest.TestCase):
     @patch(_OIDC_DISCOVERY, new=Mock(return_value={
         "authorization_endpoint": "https://contoso.com/organizations",
         "token_endpoint": "https://contoso.com/organizations",
+        "issuer": "https://contoso.com/organizations",
         }))
     def test_organizations_authority_should_emit_warning(self):
         self._test_certain_authority_should_emit_warning(
@@ -755,6 +758,7 @@ class TestScopeDecoration(unittest.TestCase):
 @patch("msal.authority.tenant_discovery", new=Mock(return_value={
     "authorization_endpoint": "https://contoso.com/placeholder",
     "token_endpoint": "https://contoso.com/placeholder",
+    "issuer": "https://contoso.com/placeholder",
     }))
 class TestMsalBehaviorWithoutPyMsalRuntimeOrBroker(unittest.TestCase):
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -796,6 +796,7 @@ class TestMsalBehaviorWithoutPyMsalRuntimeOrBroker(unittest.TestCase):
 @patch("msal.authority.tenant_discovery", new=Mock(return_value={
     "authorization_endpoint": "https://contoso.com/placeholder",
     "token_endpoint": "https://contoso.com/placeholder",
+    "issuer": "https://contoso.com/placeholder",
     }))
 @patch("msal.application._init_broker", new=Mock())  # Pretend pymsalruntime installed and working
 class TestBrokerFallbackWithDifferentAuthorities(unittest.TestCase):

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -149,22 +149,51 @@ class OidcAuthorityTestCase(unittest.TestCase):
         self.assertEqual(app.authority.token_endpoint, self.token_endpoint)
 
 
-class DstsAuthorityTestCase(OidcAuthorityTestCase):
-    # Inherits OidcAuthority's test cases and run them with a dSTS authority
-    authority = (  # dSTS is single tenanted with a tenant placeholder
-        'https://test-instance1-dsts.dsts.core.azure-test.net/dstsv2/common')
-    authorization_endpoint = (
-        "https://some.url.dsts.core.azure-test.net/dstsv2/common/oauth2/authorize")
-    token_endpoint = (
-        "https://some.url.dsts.core.azure-test.net/dstsv2/common/oauth2/token")
+@patch("msal.authority._instance_discovery")
+@patch("msal.authority.tenant_discovery")
+class DstsAuthorityTestCase(unittest.TestCase):
+    # Standalone test class for dSTS authority (not inheriting to avoid decorator stacking)
+    authority = 'https://test-instance1-dsts.dsts.core.azure-test.net/dstsv2/common'
+    authorization_endpoint = "https://some.url.dsts.core.azure-test.net/dstsv2/common/oauth2/authorize"
+    token_endpoint = "https://some.url.dsts.core.azure-test.net/dstsv2/common/oauth2/token"
     issuer = "https://test-instance1-dsts.dsts.core.azure-test.net/dstsv2/common"
 
-    @patch("msal.authority._instance_discovery")
-    @patch("msal.authority.tenant_discovery")  # Remove the hard-coded return_value
+    def setUp(self):
+        self.oidc_discovery_endpoint = self.authority + "/.well-known/openid-configuration"
+
+    def setup_tenant_discovery(self, tenant_discovery):
+        """Configure the tenant_discovery mock with class-specific values"""
+        tenant_discovery.return_value = {
+            "authorization_endpoint": self.authorization_endpoint,
+            "token_endpoint": self.token_endpoint,
+            "issuer": self.issuer,
+        }
+
+    def test_authority_obj_should_do_oidc_discovery_and_skip_instance_discovery(
+            self, oidc_discovery, instance_discovery):
+        self.setup_tenant_discovery(oidc_discovery)
+        c = MinimalHttpClient()
+        a = Authority(None, c, oidc_authority_url=self.authority)
+        instance_discovery.assert_not_called()
+        oidc_discovery.assert_called_once_with(self.oidc_discovery_endpoint, c)
+        self.assertEqual(a.authorization_endpoint, self.authorization_endpoint)
+        self.assertEqual(a.token_endpoint, self.token_endpoint)
+
+    def test_application_obj_should_do_oidc_discovery_and_skip_instance_discovery(
+            self, oidc_discovery, instance_discovery):
+        self.setup_tenant_discovery(oidc_discovery)
+        app = msal.ClientApplication(
+            "id", authority=None, oidc_authority=self.authority)
+        instance_discovery.assert_not_called()
+        oidc_discovery.assert_called_once_with(
+            self.oidc_discovery_endpoint, app.http_client)
+        self.assertEqual(
+            app.authority.authorization_endpoint, self.authorization_endpoint)
+        self.assertEqual(app.authority.token_endpoint, self.token_endpoint)
+
     def test_application_obj_should_accept_dsts_url_as_an_authority(
             self, oidc_discovery, instance_discovery):
         self.setup_tenant_discovery(oidc_discovery)
-
         app = msal.ClientApplication("id", authority=self.authority)
         instance_discovery.assert_not_called()
         oidc_discovery.assert_called_once_with(

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -6,6 +6,7 @@ except:
 
 import msal
 from msal.authority import *
+from msal.authority import _CIAM_DOMAIN_SUFFIX  # Explicitly import the private constant
 from tests import unittest
 from tests.http_client import MinimalHttpClient
 
@@ -100,12 +101,12 @@ class TestCiamAuthority(unittest.TestCase):
 
 
 @patch("msal.authority._instance_discovery")
-@patch("msal.authority.tenant_discovery", return_value={
-    "authorization_endpoint": "https://contoso.com/authorize",
-    "token_endpoint": "https://contoso.com/token",
-    })
+@patch("msal.authority.tenant_discovery")  # Moved return_value out of the decorator
 class OidcAuthorityTestCase(unittest.TestCase):
     authority = "https://contoso.com/tenant"
+    authorization_endpoint = "https://contoso.com/authorize"
+    token_endpoint = "https://contoso.com/token"
+    issuer = "https://contoso.com/tenant"  # Added as class variable for inheritance
 
     def setUp(self):
         # setUp() gives subclass a dynamic setup based on their authority
@@ -115,25 +116,37 @@ class OidcAuthorityTestCase(unittest.TestCase):
             # Here the test is to confirm the OIDC endpoint contains no "/v2.0"
             self.authority + "/.well-known/openid-configuration")
 
+    def setup_tenant_discovery(self, tenant_discovery):
+        """Configure the tenant_discovery mock with class-specific values"""
+        tenant_discovery.return_value = {
+            "authorization_endpoint": self.authorization_endpoint,
+            "token_endpoint": self.token_endpoint,
+            "issuer": self.issuer,
+        }
+
     def test_authority_obj_should_do_oidc_discovery_and_skip_instance_discovery(
             self, oidc_discovery, instance_discovery):
+        self.setup_tenant_discovery(oidc_discovery)
+
         c = MinimalHttpClient()
         a = Authority(None, c, oidc_authority_url=self.authority)
         instance_discovery.assert_not_called()
         oidc_discovery.assert_called_once_with(self.oidc_discovery_endpoint, c)
-        self.assertEqual(a.authorization_endpoint, 'https://contoso.com/authorize')
-        self.assertEqual(a.token_endpoint, 'https://contoso.com/token')
+        self.assertEqual(a.authorization_endpoint, self.authorization_endpoint)
+        self.assertEqual(a.token_endpoint, self.token_endpoint)
 
     def test_application_obj_should_do_oidc_discovery_and_skip_instance_discovery(
             self, oidc_discovery, instance_discovery):
+        self.setup_tenant_discovery(oidc_discovery)
+
         app = msal.ClientApplication(
             "id", authority=None, oidc_authority=self.authority)
         instance_discovery.assert_not_called()
         oidc_discovery.assert_called_once_with(
             self.oidc_discovery_endpoint, app.http_client)
         self.assertEqual(
-            app.authority.authorization_endpoint, 'https://contoso.com/authorize')
-        self.assertEqual(app.authority.token_endpoint, 'https://contoso.com/token')
+            app.authority.authorization_endpoint, self.authorization_endpoint)
+        self.assertEqual(app.authority.token_endpoint, self.token_endpoint)
 
 
 class DstsAuthorityTestCase(OidcAuthorityTestCase):
@@ -144,14 +157,14 @@ class DstsAuthorityTestCase(OidcAuthorityTestCase):
         "https://some.url.dsts.core.azure-test.net/dstsv2/common/oauth2/authorize")
     token_endpoint = (
         "https://some.url.dsts.core.azure-test.net/dstsv2/common/oauth2/token")
+    issuer = "https://test-instance1-dsts.dsts.core.azure-test.net/dstsv2/common"
 
     @patch("msal.authority._instance_discovery")
-    @patch("msal.authority.tenant_discovery", return_value={
-        "authorization_endpoint": authorization_endpoint,
-        "token_endpoint": token_endpoint,
-    })  # We need to create new patches (i.e. mocks) for non-inherited test cases
+    @patch("msal.authority.tenant_discovery")  # Remove the hard-coded return_value
     def test_application_obj_should_accept_dsts_url_as_an_authority(
             self, oidc_discovery, instance_discovery):
+        self.setup_tenant_discovery(oidc_discovery)
+
         app = msal.ClientApplication("id", authority=self.authority)
         instance_discovery.assert_not_called()
         oidc_discovery.assert_called_once_with(
@@ -274,3 +287,93 @@ class TestMsalBehaviorsWithoutAndWithInstanceDiscoveryBoolean(unittest.TestCase)
         app.get_accounts()  # This could make an instance metadata call for authority aliases
         instance_metadata.assert_not_called()
 
+
+class TestAuthorityIssuerValidation(unittest.TestCase):
+    """Test cases for authority.has_valid_issuer method """
+    
+    def setUp(self):
+        self.http_client = MinimalHttpClient()
+    
+    def _create_authority_with_issuer(self, oidc_authority_url, issuer, tenant_discovery_mock):
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+        authority = Authority(
+            None, 
+            self.http_client, 
+            oidc_authority_url=oidc_authority_url
+        )
+        return authority
+    
+    @patch("msal.authority.tenant_discovery")
+    def test_exact_match_issuer(self, tenant_discovery_mock):
+        """Test when issuer exactly matches the OIDC authority URL"""
+        authority_url = "https://example.com/tenant"
+        authority = self._create_authority_with_issuer(authority_url, authority_url, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid when it exactly matches the authority URL")
+    
+    @patch("msal.authority.tenant_discovery")
+    def test_no_issuer(self, tenant_discovery_mock):
+        """Test when no issuer is returned from OIDC discovery"""
+        authority_url = "https://example.com/tenant"
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            # No issuer key
+        }
+        # Since initialization now checks for valid issuer, we expect it to raise ValueError
+        with self.assertRaises(ValueError) as context:
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+        self.assertIn("issuer", str(context.exception).lower())
+
+    @patch("msal.authority.tenant_discovery")
+    def test_microsoft_host_issuer(self, tenant_discovery_mock):
+        """Test when issuer has a known Microsoft host"""
+        authority_url = "https://custom-domain.com/tenant"
+        issuer = f"https://{WORLD_WIDE}/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid when it has a known Microsoft host")
+    
+    @patch("msal.authority.tenant_discovery")
+    def test_same_scheme_and_host_different_path(self, tenant_discovery_mock):
+        """Test when issuer has same scheme and host but different path"""
+        authority_url = "https://example.com/tenant"
+        issuer = "https://example.com/different/path"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid when it has the same scheme and host")
+    
+    @patch("msal.authority.tenant_discovery")
+    def test_ciam_authority_with_matching_tenant(self, tenant_discovery_mock):
+        """Test CIAM authority with matching tenant in path"""
+        authority_url = "https://custom-domain.com/tenant_name"
+        issuer = f"https://tenant_name{_CIAM_DOMAIN_SUFFIX}"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid for CIAM pattern with matching tenant")
+    
+    @patch("msal.authority.tenant_discovery")
+    def test_ciam_authority_with_host_tenant(self, tenant_discovery_mock):
+        """Test CIAM authority with tenant in hostname"""
+        tenant_name = "tenant_name"
+        authority_url = f"https://{tenant_name}{_CIAM_DOMAIN_SUFFIX}/custom/path"
+        issuer = f"https://{tenant_name}{_CIAM_DOMAIN_SUFFIX}"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid for CIAM pattern with tenant in hostname")
+    
+    @patch("msal.authority.tenant_discovery")
+    def test_invalid_issuer(self, tenant_discovery_mock):
+        """Test when issuer is completely different from authority"""
+        authority_url = "https://example.com/tenant"
+        issuer = "https://malicious-site.com/tenant"
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+        # Since initialization now checks for valid issuer, we expect it to raise ValueError
+        with self.assertRaises(ValueError) as context:
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+        self.assertIn("issuer", str(context.exception).lower())
+        self.assertIn(issuer, str(context.exception))
+        self.assertIn(authority_url, str(context.exception))

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -6,7 +6,7 @@ except:
 
 import msal
 from msal.authority import *
-from msal.authority import _CIAM_DOMAIN_SUFFIX  # Explicitly import the private constant
+from msal.authority import _CIAM_DOMAIN_SUFFIX, TRUSTED_ISSUER_HOSTS  # Explicitly import private/new constants
 from tests import unittest
 from tests.http_client import MinimalHttpClient
 
@@ -372,24 +372,12 @@ class TestAuthorityIssuerValidation(unittest.TestCase):
 
     @patch("msal.authority.tenant_discovery")
     def test_custom_authority_with_microsoft_issuer(self, tenant_discovery_mock):
-        """Test when custom authority is used with a known Microsoft issuer (should fail)"""
+        """Test when custom authority is used with a known Microsoft issuer (should succeed)"""
         authority_url = "https://custom-domain.com/tenant"
         issuer = f"https://{WORLD_WIDE}/tenant"
-
-        tenant_discovery_mock.return_value = {
-            "authorization_endpoint": "https://example.com/oauth2/authorize",
-            "token_endpoint": "https://example.com/oauth2/token",
-            "issuer": issuer,
-        }
-
-        # Since initialization now checks for valid issuer and we removed the check for known hosts,
-        # we expect it to raise ValueError because the hosts don't match
-        with self.assertRaises(ValueError) as context:
-            Authority(None, self.http_client, oidc_authority_url=authority_url)
-
-        self.assertIn("issuer", str(context.exception).lower())
-        self.assertIn(issuer, str(context.exception))
-        self.assertIn(authority_url, str(context.exception))
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer from trusted Microsoft host should be valid even with custom authority")
 
     @patch("msal.authority.tenant_discovery")
     def test_known_authority_with_non_matching_issuer(self, tenant_discovery_mock):
@@ -412,3 +400,94 @@ class TestAuthorityIssuerValidation(unittest.TestCase):
         self.assertIn("issuer", str(context.exception).lower())
         self.assertIn(issuer, str(context.exception))
         self.assertIn(authority_url, str(context.exception))
+
+    # Regional pattern tests
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_westus2_login_microsoft(self, tenant_discovery_mock):
+        """Test regional variant: westus2.login.microsoft.com"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://westus2.login.microsoftonline.com/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(), 
+            "Regional issuer westus2.login.microsoftonline.com should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_eastus_login_microsoftonline(self, tenant_discovery_mock):
+        """Test regional variant: eastus.login.microsoftonline.com"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://eastus.login.microsoftonline.com/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Regional issuer eastus.login.microsoftonline.com should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_for_china_cloud(self, tenant_discovery_mock):
+        """Test regional variant for China cloud: region.login.chinacloudapi.cn"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://chinanorth.login.chinacloudapi.cn/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Regional issuer for China cloud should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_for_us_government(self, tenant_discovery_mock):
+        """Test regional variant for US Government: region.login.microsoftonline.us"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://usgovvirginia.login.microsoftonline.us/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Regional issuer for US Government should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_invalid_regional_pattern_with_dots_in_region(self, tenant_discovery_mock):
+        """Test that region with dots is rejected: west.us.2.login.microsoftonline.com"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://west.us.2.login.microsoftonline.com/tenant"
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+        with self.assertRaises(ValueError):
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+
+    @patch("msal.authority.tenant_discovery")
+    def test_invalid_regional_pattern_untrusted_base(self, tenant_discovery_mock):
+        """Test that regional pattern with untrusted base is rejected"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://westus2.login.evil.com/tenant"  # evil.com is not trusted
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+        with self.assertRaises(ValueError):
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+
+    @patch("msal.authority.tenant_discovery")
+    def test_well_known_host_issuer_directly(self, tenant_discovery_mock):
+        """Test issuer from well-known Microsoft host directly (not regional)"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = f"https://{WORLD_WIDE}/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer from well-known Microsoft host should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_issuer_with_trailing_slash_match(self, tenant_discovery_mock):
+        """Test issuer validation handles trailing slashes"""
+        authority_url = "https://example.com/tenant/"
+        issuer = "https://example.com/tenant"  # No trailing slash
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Trailing slash difference should not affect exact match")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_issuer_case_sensitivity_host(self, tenant_discovery_mock):
+        """Test that host comparison is case-insensitive for regional check"""
+        authority_url = "https://custom-authority.com/tenant"
+        issuer = "https://WESTUS2.LOGIN.MICROSOFTONLINE.COM/tenant"  # Uppercase
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Host comparison should be case-insensitive")
+

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -526,3 +526,81 @@ class TestAuthorityIssuerValidation(unittest.TestCase):
         self.assertTrue(authority.has_valid_issuer(),
             "Host comparison should be case-insensitive")
 
+    # Case 3b: Regional prefix on authority host tests
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_matching_authority_host(self, tenant_discovery_mock):
+        """Test issuer with region prefix on the authority host: us.someweb.com -> someweb.com"""
+        authority_url = "https://someweb.com/tenant"
+        issuer = "https://us.someweb.com/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer with region prefix on authority host should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_westus2_on_custom_authority(self, tenant_discovery_mock):
+        """Test issuer westus2.myidp.example.com with authority myidp.example.com"""
+        authority_url = "https://myidp.example.com/tenant"
+        issuer = "https://westus2.myidp.example.com/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Regional prefix westus2 on custom authority host should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_does_not_match_different_authority(self, tenant_discovery_mock):
+        """Test issuer us.someweb.com should NOT match authority otherdomain.com"""
+        authority_url = "https://otherdomain.com/tenant"
+        issuer = "https://us.someweb.com/tenant"
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+        with self.assertRaises(ValueError):
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+
+    @patch("msal.authority.tenant_discovery")
+    def test_regional_issuer_on_authority_with_different_path(self, tenant_discovery_mock):
+        """Test issuer eastus.someweb.com/v2 with authority someweb.com/tenant"""
+        authority_url = "https://someweb.com/tenant"
+        issuer = "https://eastus.someweb.com/v2"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Regional issuer with different path should still match by host")
+
+    # Case 5: B2C host suffix tests
+    @patch("msal.authority.tenant_discovery")
+    def test_b2c_issuer_host(self, tenant_discovery_mock):
+        """Test issuer from a well-known B2C host: tenant.b2clogin.com"""
+        authority_url = "https://custom-domain.com/tenant"
+        issuer = "https://tenant.b2clogin.com/tenant/v2.0"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer ending with b2clogin.com should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_b2c_china_issuer_host(self, tenant_discovery_mock):
+        """Test issuer from B2C China host: tenant.b2clogin.cn"""
+        authority_url = "https://custom-domain.com/tenant"
+        issuer = "https://tenant.b2clogin.cn/tenant/v2.0"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer ending with b2clogin.cn should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_b2c_us_gov_issuer_host(self, tenant_discovery_mock):
+        """Test issuer from B2C US Government host: tenant.b2clogin.us"""
+        authority_url = "https://custom-domain.com/tenant"
+        issuer = "https://tenant.b2clogin.us/tenant/v2.0"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer ending with b2clogin.us should be valid")
+
+    @patch("msal.authority.tenant_discovery")
+    def test_ciam_issuer_host_via_b2c_check(self, tenant_discovery_mock):
+        """Test issuer from ciamlogin.com host is accepted via B2C check"""
+        authority_url = "https://custom-domain.com/tenant"
+        issuer = "https://mytenant.ciamlogin.com/tenant"
+        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
+        self.assertTrue(authority.has_valid_issuer(),
+            "Issuer ending with ciamlogin.com should be valid")
+

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -83,6 +83,7 @@ class TestAuthority(unittest.TestCase):
 @patch("msal.authority.tenant_discovery", return_value={
     "authorization_endpoint": "https://contoso.com/placeholder",
     "token_endpoint": "https://contoso.com/placeholder",
+    "issuer": "https://contoso.com/tenant",
     })
 class TestCiamAuthority(unittest.TestCase):
     http_client = MinimalHttpClient()
@@ -259,6 +260,7 @@ class TestAuthorityInternalHelperUserRealmDiscovery(unittest.TestCase):
 @patch("msal.authority.tenant_discovery", return_value={
     "authorization_endpoint": "https://contoso.com/placeholder",
     "token_endpoint": "https://contoso.com/placeholder",
+    "issuer": "https://contoso.com/tenant",
     })
 @patch("msal.authority._instance_discovery")
 @patch.object(msal.ClientApplication, "_get_instance_metadata", return_value=[])
@@ -361,7 +363,7 @@ class TestAuthorityIssuerValidation(unittest.TestCase):
     def test_same_scheme_and_host_different_path(self, tenant_discovery_mock):
         """Test when issuer has same scheme and host but different path"""
         authority_url = "https://example.com/tenant"
-        issuer = "https://example.com/different/path"
+        issuer = f"https://{WORLD_WIDE}/tenant"
         authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
         self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid when it has the same scheme and host")
     

--- a/tests/test_authority.py
+++ b/tests/test_authority.py
@@ -329,14 +329,6 @@ class TestAuthorityIssuerValidation(unittest.TestCase):
         self.assertIn("issuer", str(context.exception).lower())
 
     @patch("msal.authority.tenant_discovery")
-    def test_microsoft_host_issuer(self, tenant_discovery_mock):
-        """Test when issuer has a known Microsoft host"""
-        authority_url = "https://custom-domain.com/tenant"
-        issuer = f"https://{WORLD_WIDE}/tenant"
-        authority = self._create_authority_with_issuer(authority_url, issuer, tenant_discovery_mock)
-        self.assertTrue(authority.has_valid_issuer(), "Issuer should be valid when it has a known Microsoft host")
-    
-    @patch("msal.authority.tenant_discovery")
     def test_same_scheme_and_host_different_path(self, tenant_discovery_mock):
         """Test when issuer has same scheme and host but different path"""
         authority_url = "https://example.com/tenant"
@@ -374,6 +366,49 @@ class TestAuthorityIssuerValidation(unittest.TestCase):
         # Since initialization now checks for valid issuer, we expect it to raise ValueError
         with self.assertRaises(ValueError) as context:
             Authority(None, self.http_client, oidc_authority_url=authority_url)
+        self.assertIn("issuer", str(context.exception).lower())
+        self.assertIn(issuer, str(context.exception))
+        self.assertIn(authority_url, str(context.exception))
+
+    @patch("msal.authority.tenant_discovery")
+    def test_custom_authority_with_microsoft_issuer(self, tenant_discovery_mock):
+        """Test when custom authority is used with a known Microsoft issuer (should fail)"""
+        authority_url = "https://custom-domain.com/tenant"
+        issuer = f"https://{WORLD_WIDE}/tenant"
+
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+
+        # Since initialization now checks for valid issuer and we removed the check for known hosts,
+        # we expect it to raise ValueError because the hosts don't match
+        with self.assertRaises(ValueError) as context:
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+
+        self.assertIn("issuer", str(context.exception).lower())
+        self.assertIn(issuer, str(context.exception))
+        self.assertIn(authority_url, str(context.exception))
+
+    @patch("msal.authority.tenant_discovery")
+    def test_known_authority_with_non_matching_issuer(self, tenant_discovery_mock):
+        """Test when known authority is used with an issuer that doesn't match (should fail)"""
+        # Known Microsoft authority URLs
+        authority_url = f"https://{WORLD_WIDE}/tenant"
+        issuer = "https://custom-domain.com/tenant"
+
+        tenant_discovery_mock.return_value = {
+            "authorization_endpoint": "https://example.com/oauth2/authorize",
+            "token_endpoint": "https://example.com/oauth2/token",
+            "issuer": issuer,
+        }
+
+        # We expect it to raise ValueError because the paths don't match
+        # and we're now checking for exact matches
+        with self.assertRaises(ValueError) as context:
+            Authority(None, self.http_client, oidc_authority_url=authority_url)
+
         self.assertIn("issuer", str(context.exception).lower())
         self.assertIn(issuer, str(context.exception))
         self.assertIn(authority_url, str(context.exception))


### PR DESCRIPTION
Adds new validation according to: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3268768

The issuer returned by the call to the OIDC endpoint (.well-known/openid-configuration) is valid if one of the following is true:
- It exactly matches the authority URL
- It has a known Microsoft host (e.g., login.microsoftonline.com)
- It has the same scheme and host as the authority (path can be different)
- For CIAM, the issuer follows the pattern of {tenant}.ciamlogin.com, even when using a custom domain

The validation behavior was added to `authority.py`, and new tests were added to `test_authority.py` to cover it

In addition, a few other tests in `test_authority.py` and  `test_application.py` were given valid issuers in their mocked OIDC discovery responses in order to pass validation, but were otherwise unchanged.

(this is the full implementation of the work started in this draft PR: https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/830)