### PR TITLE
MSAL Python 1.33.0

### DIFF
--- a/msal/sku.py
+++ b/msal/sku.py
@@ -2,5 +2,5 @@
 """
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.33.0b1"
+__version__ = "1.33.0"
 SKU = "MSAL.Python"


### PR DESCRIPTION
In order to allow a small-yet-meaningful percentage of MSAL users to trial our new releases, we aim to always ship a beta version before EACH stable version, starting from version 1.33.0b1.

[In the recent weeks, there have roughly been 300k daily downloads for beta release 1.33.0b1, which is about 10% of daily downloads of the latest stable version 1.32.3](https://pepy.tech/projects/msal?timeRange=threeMonths&category=version&includeCIDownloads=true&granularity=daily&viewType=line&versions=1.32.3%2C1.32.2%2C1.32.1%2C1.33.0b1%2C1.*), and we have zero bug report. It is about time to re-ship the beta 1.33.0b1 as a stable 1.33.0.

<img width="622" height="666" alt="image" src="https://github.com/user-attachments/assets/d153b42f-235c-4e04-ab99-d4dfd4d29e16" />

