### PR TITLE
Change the value of "x-client-os" header

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -2,6 +2,7 @@ import functools
 import json
 import time
 import logging
+import platform
 import sys
 import warnings
 from threading import Lock
@@ -789,7 +790,7 @@ The reserved list: {}""".format(list(scope_set), list(reserved_scope)))
         client_assertion_type = None
         default_headers = {
             "x-client-sku": SKU, "x-client-ver": __version__,
-            "x-client-os": sys.platform,
+            "x-client-os": platform.system(),
             "x-ms-lib-capability": "retry-after, h429",
         }
         if self.app_name:


### PR DESCRIPTION
eSTS expects we send x-client-os: Windows instead of win32 as there are no OS called win 32. win32 is not a recognized OS string in the current server-side platform detection logic.