### PR TITLE
Set Redirect Uri for broker silent flow on Linux platform

### DIFF
--- a/msal/broker.py
+++ b/msal/broker.py
@@ -145,17 +145,20 @@ def _build_msal_runtime_auth_params(client_id, authority):
     params.set_additional_parameter("msal_client_ver", __version__)
     return params
 
+def _set_redirect_uri_for_linux(params):
+    if sys.platform == "linux":
+        # This is required by Linux Java Broker to set a non-empty valid redirect_uri
+        params.set_redirect_uri(
+            "https://login.microsoftonline.com/common/oauth2/nativeclient"
+        )
+
 def _signin_silently(
         authority, client_id, scopes, correlation_id=None, claims=None,
         enable_msa_pt=False,
         auth_scheme=None,
         **kwargs):
     params = _build_msal_runtime_auth_params(client_id, authority)
-    if sys.platform == "linux":
-        # This is required by Linux Java Broker to set a non-empty valid redirect_uri
-        params.set_redirect_uri(
-            "https://login.microsoftonline.com/common/oauth2/nativeclient"
-        )
+    _set_redirect_uri_for_linux(params)
     params.set_requested_scopes(scopes)
     if claims:
         params.set_decoded_claims(claims)
@@ -245,11 +248,7 @@ def _acquire_token_silently(
     if account is None:
         return
     params = _build_msal_runtime_auth_params(client_id, authority)
-    if sys.platform == "linux":
-        # This is required by Linux Java Broker to set a non-empty valid redirect_uri
-        params.set_redirect_uri(
-            "https://login.microsoftonline.com/common/oauth2/nativeclient"
-        )
+    _set_redirect_uri_for_linux(params)
     params.set_requested_scopes(scopes)
     if claims:
         params.set_decoded_claims(claims)

--- a/msal/broker.py
+++ b/msal/broker.py
@@ -151,6 +151,11 @@ def _signin_silently(
         auth_scheme=None,
         **kwargs):
     params = _build_msal_runtime_auth_params(client_id, authority)
+    if sys.platform == "linux":
+        # This is required by Linux Java Broker to set a non-empty valid redirect_uri
+        params.set_redirect_uri(
+            "https://login.microsoftonline.com/common/oauth2/nativeclient"
+        )
     params.set_requested_scopes(scopes)
     if claims:
         params.set_decoded_claims(claims)
@@ -240,6 +245,11 @@ def _acquire_token_silently(
     if account is None:
         return
     params = _build_msal_runtime_auth_params(client_id, authority)
+    if sys.platform == "linux":
+        # This is required by Linux Java Broker to set a non-empty valid redirect_uri
+        params.set_redirect_uri(
+            "https://login.microsoftonline.com/common/oauth2/nativeclient"
+        )
     params.set_requested_scopes(scopes)
     if claims:
         params.set_decoded_claims(claims)


### PR DESCRIPTION
Customer got 'redirectUri is NULL or EMPTY|illegal_argument_exception' on Linux platform due to the authParameter check in Linux Java broker. Set the redirect uri to default in silent flow on Linux platform to resolve the issue.