### PR TITLE
Declare support for Python 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 


### PR DESCRIPTION
This PR fixes #848 and fixes #850.

It will be shipped as MSAL Python 1.34.0 soon.