### PR TITLE
Release 1.34.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/msal/sku.py
+++ b/msal/sku.py
@@ -2,5 +2,5 @@
 """
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.34.0b1"
+__version__ = "1.34.0"
 SKU = "MSAL.Python"

--- a/msal/sku.py
+++ b/msal/sku.py
@@ -2,5 +2,5 @@
 """
 
 # The __init__.py will import this. Not the other way around.
-__version__ = "1.33.0"
+__version__ = "1.34.0b1"
 SKU = "MSAL.Python"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -39,7 +38,7 @@ project_urls =
 include_package_data = False  # We used to ship LICENSE, but our __init__.py already mentions MIT
 packages = find:
 # Our test pipeline currently still covers Py37
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     requests>=2.0.0,<3
 
@@ -53,7 +52,7 @@ install_requires =
     # And we will use the cryptography (X+3).0.0 as the upper bound,
     # based on their latest deprecation policy
     # https://cryptography.io/en/latest/api-stability/#deprecation
-    cryptography>=2.5,<48
+    cryptography>=2.5,<49
 
 
 [options.extras_require]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -841,12 +841,14 @@ class AtPopWithExternalKeyTestCase(PopWithExternalKeyTestCase):
 
 
 class WorldWideTestCase(LabBasedTestCase):
+    _ADFS_LABS_DECOMMISSIONED = "ADFS labs were decommissioned since July 2025 until further notice"
 
     def test_aad_managed_user(self):  # Pure cloud
         config = self.get_lab_user(usertype="cloud")
         config["password"] = self.get_lab_user_secret(config["lab_name"])
         self._test_username_password(**config)
 
+    @unittest.skip(_ADFS_LABS_DECOMMISSIONED)
     def test_adfs4_fed_user(self):
         config = self.get_lab_user(usertype="federated", federationProvider="ADFSv4")
         config["password"] = self.get_lab_user_secret(config["lab_name"])
@@ -864,6 +866,7 @@ class WorldWideTestCase(LabBasedTestCase):
         config["password"] = self.get_lab_user_secret(config["lab_name"])
         self._test_username_password(**config)
 
+    @unittest.skip(_ADFS_LABS_DECOMMISSIONED)
     def test_adfs2019_fed_user(self):
         try:
             config = self.get_lab_user(usertype="federated", federationProvider="ADFSv2019")
@@ -892,6 +895,7 @@ class WorldWideTestCase(LabBasedTestCase):
             prompt="select_account",  # In MSAL Python, this resets login_hint
             ))
 
+    @unittest.skip(_ADFS_LABS_DECOMMISSIONED)
     def test_ropc_adfs2019_onprem(self):
         # Configuration is derived from https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/4.7.0/tests/Microsoft.Identity.Test.Common/TestConstants.cs#L250-L259
         config = self.get_lab_user(usertype="onprem", federationProvider="ADFSv2019")
@@ -900,6 +904,7 @@ class WorldWideTestCase(LabBasedTestCase):
         config["password"] = self.get_lab_user_secret(config["lab_name"])
         self._test_username_password(**config)
 
+    @unittest.skip(_ADFS_LABS_DECOMMISSIONED)
     def test_adfs2019_onprem_acquire_token_by_auth_code(self):
         """When prompted, you can manually login using this account:
 
@@ -913,6 +918,7 @@ class WorldWideTestCase(LabBasedTestCase):
         config["port"] = 8080
         self._test_acquire_token_by_auth_code(**config)
 
+    @unittest.skip(_ADFS_LABS_DECOMMISSIONED)
     def test_adfs2019_onprem_acquire_token_by_auth_code_flow(self):
         config = self.get_lab_user(usertype="onprem", federationProvider="ADFSv2019")
         self._test_acquire_token_by_auth_code_flow(**dict(
@@ -922,6 +928,7 @@ class WorldWideTestCase(LabBasedTestCase):
             port=8080,
             ))
 
+    @unittest.skip(_ADFS_LABS_DECOMMISSIONED)
     def test_adfs2019_onprem_acquire_token_interactive(self):
         config = self.get_lab_user(usertype="onprem", federationProvider="ADFSv2019")
         self._test_acquire_token_interactive(**dict(


### PR DESCRIPTION
Merging release 1.34 branch back to default branch.

Note: You can ignore the CI/CD failure of this PR. It was failing only because it was attempting to run the publish pipeline. But we are not using the standard release process this time.