### PR TITLE
Deprecate the params field of _obtain_token

### DIFF
--- a/msal/oauth2cli/oauth2.py
+++ b/msal/oauth2cli/oauth2.py
@@ -184,14 +184,23 @@ class BaseClient(object):
 
     def _obtain_token(  # The verb "obtain" is influenced by OAUTH2 RFC 6749
             self, grant_type,
-            params=None,  # a dict to be sent as query string to the endpoint
             data=None,  # All relevant data, which will go into the http body
             headers=None,  # a dict to be sent as request headers
             post=None,  # A callable to replace requests.post(), for testing.
-                        # Such as: lambda url, **kwargs:
-                        #   Mock(status_code=200, text='{}')
             **kwargs  # Relay all extra parameters to underlying requests
-            ):  # Returns the json object came from the OAUTH2 response
+            ):
+
+        # Handle deprecated params parameter
+        params = kwargs.pop('params', None)
+        if params is not None:
+            import warnings
+            warnings.warn(
+                "Setting 'params' is recommended for production scenarios. "
+                "It will be removed in a future release, and the behavior may be replaced by a new API.",
+                FutureWarning,
+                stacklevel=2
+            )
+
         _data = {'client_id': self.client_id, 'grant_type': grant_type}
 
         if self.default_body.get("client_assertion_type") and self.client_assertion:

--- a/msal/oauth2cli/oauth2.py
+++ b/msal/oauth2cli/oauth2.py
@@ -187,8 +187,10 @@ class BaseClient(object):
             data=None,  # All relevant data, which will go into the http body
             headers=None,  # a dict to be sent as request headers
             post=None,  # A callable to replace requests.post(), for testing.
+                        # Such as: lambda url, **kwargs:
+                        #   Mock(status_code=200, text='{}')
             **kwargs  # Relay all extra parameters to underlying requests
-            ):
+            ):  # Returns the json object came from the OAUTH2 response
 
         # Handle deprecated params parameter
         params = kwargs.pop('params', None)
@@ -784,14 +786,14 @@ class Client(BaseClient):  # We choose to implement all 4 grants in 1 class
             also_save_rt=False,
             on_obtaining_tokens=None,
             *args, **kwargs):
-        _data = data.copy() if data else {}  # to prevent side effect
+        _data = data.copy()  # to prevent side effect
         
         # Handle deprecated params parameter. It was removed as an argument here and in BaseClient._obtain_token(),
         # and BaseClient._obtain_token() provides the deprecation warning if params is used.
         params = kwargs.pop('params', None)
         
         resp = super(Client, self)._obtain_token(
-            grant_type, data=_data, *args, **kwargs)
+            grant_type, _data, *args, **kwargs)
         if "error" not in resp:
             _resp = resp.copy()
             RT = "refresh_token"

--- a/msal/oauth2cli/oauth2.py
+++ b/msal/oauth2cli/oauth2.py
@@ -187,10 +187,8 @@ class BaseClient(object):
             data=None,  # All relevant data, which will go into the http body
             headers=None,  # a dict to be sent as request headers
             post=None,  # A callable to replace requests.post(), for testing.
-                        # Such as: lambda url, **kwargs:
-                        #   Mock(status_code=200, text='{}')
             **kwargs  # Relay all extra parameters to underlying requests
-            ):  # Returns the json object came from the OAUTH2 response
+            ):
 
         # Handle deprecated params parameter
         params = kwargs.pop('params', None)
@@ -782,13 +780,18 @@ class Client(BaseClient):  # We choose to implement all 4 grants in 1 class
         self.on_updating_rt = on_updating_rt
 
     def _obtain_token(
-            self, grant_type, params=None, data=None,
+            self, grant_type, data=None,
             also_save_rt=False,
             on_obtaining_tokens=None,
             *args, **kwargs):
-        _data = data.copy()  # to prevent side effect
+        _data = data.copy() if data else {}  # to prevent side effect
+        
+        # Handle deprecated params parameter. It was removed as an argument here and in BaseClient._obtain_token(),
+        # and BaseClient._obtain_token() provides the deprecation warning if params is used.
+        params = kwargs.pop('params', None)
+        
         resp = super(Client, self)._obtain_token(
-            grant_type, params, _data, *args, **kwargs)
+            grant_type, data=_data, *args, **kwargs)
         if "error" not in resp:
             _resp = resp.copy()
             RT = "refresh_token"

--- a/msal/oauth2cli/oauth2.py
+++ b/msal/oauth2cli/oauth2.py
@@ -187,8 +187,10 @@ class BaseClient(object):
             data=None,  # All relevant data, which will go into the http body
             headers=None,  # a dict to be sent as request headers
             post=None,  # A callable to replace requests.post(), for testing.
+                        # Such as: lambda url, **kwargs:
+                        #   Mock(status_code=200, text='{}')
             **kwargs  # Relay all extra parameters to underlying requests
-            ):
+            ):  # Returns the json object came from the OAUTH2 response
 
         # Handle deprecated params parameter
         params = kwargs.pop('params', None)


### PR DESCRIPTION
Deprecates the ability to send arbitrary query parameters to a token request according to KR [3310905](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3310905), similar to what was done in other MSALs: 
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5536

https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1001

This behavior was intended for niche scenarios which the library did not explicitly cover, and not really meant for production. It can affect the contents and validity of tokens but were not used in our caching scheme which led to bad caching behavior: if the extra query parameters changed between requests we could return tokens that were not valid for the latest set of parameters.

MSAL Python did not have an explicit `WithExtraQueryParameters` API like other MSALs, however the internal `BaseClient._obtain_token` and `Client._obtain_token` functions had a `params` argument which set the query parameters just like other MSALs. A customer could define these params by setting them in the `kwargs` argument of some public APIs.

This PR removes the explicit `params` argument from those functions. For backwards compatibility we still check the `kwargs` argument for `params`, and if it is used a deprecation warning in `BaseClient._obtain_token` will inform the customer.