### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,10 @@ strategy:
       python.version: '3.11'
     Python312:
       python.version: '3.12'
+    Python313:
+      python.version: '3.13'
+    Python314:
+      python.version: '3.14'
 
 steps:
 - task: UsePythonVersion@0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
 env_list =
+    # Historically, this tox.ini is intended only for MSAL maintainer
+    # to manually test with the whatever Python 3 version available on their devbox.
+    # This way, it is unnecessary to enumerate all Python versions here.
     py3
 minversion = 4.21.2
 


### PR DESCRIPTION
[Python 3.14 was released on Oct 7, 2025](https://www.python.org/downloads/release/python-3140/). This PR officially declares MSAL's support for Python 3.14 and enables its testing in pipelines.

Also, [the newly adjusted test pipeline is passing with Python 3.14](https://github.com/AzureAD/microsoft-authentication-library-for-python/actions/runs/18990335220).