### PR TITLE
Potential fix for code scanning alert no. 74: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   ci:
+    permissions:
+      contents: read
     env:
       # Fake a TRAVIS env so that the pre-existing test cases would behave like before
       TRAVIS: true


### PR DESCRIPTION
Potential fix for [https://github.com/AzureAD/microsoft-authentication-library-for-python/security/code-scanning/74](https://github.com/AzureAD/microsoft-authentication-library-for-python/security/code-scanning/74)

To fix the problem, the `ci` job should define an explicit `permissions` block that grants only the minimal access required. Since this job only needs to read the repository contents (for `actions/checkout`) and does not need to write anywhere, `contents: read` is sufficient. This aligns it with GitHub’s least‑privilege recommendation and with the CodeQL suggestion.

Concretely, in `.github/workflows/python-package.yml`, under `jobs: ci:`, add a `permissions:` section before `env:` (or anywhere inside the `ci` job) with `contents: read`. No other changes to steps are necessary, and no additional imports or methods are required because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
