### PR TITLE
Merge e2e test fixes into PyPI-ADO-PackagePublish

### DIFF
--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -122,11 +122,6 @@ stages:
       eq(dependencies.PreBuildCheck.result, 'Succeeded'),
       in(dependencies.Validate.result, 'Succeeded', 'Skipped')
     )
-  variables:
-    # RequestMSIDLAB — the MSID Lab confidential client app used for Key Vault
-    # access and as a test subject. Matches usage in MSAL.js and MSAL Java pipelines.
-    # See https://docs.msidlab.com/accounts/confidentialclient.html
-    LAB_APP_CLIENT_ID: 'f62c5ae3-bf3a-4af5-afa8-a68b800396e9'
   jobs:
   - job: Test
     displayName: 'Run unit tests'
@@ -185,7 +180,6 @@ stages:
         pytest -vv --junitxml=test-results/junit.xml 2>&1 | tee test-results/pytest.log
       displayName: 'Run tests'
       env:
-        LAB_APP_CLIENT_ID: $(LAB_APP_CLIENT_ID)
         LAB_APP_CLIENT_CERT_PFX_PATH: $(LAB_APP_CLIENT_CERT_PFX_PATH)
 
     - task: PublishTestResults@2

--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -183,13 +183,12 @@ stages:
         pytest -vv --junitxml=test-results/junit.xml 2>&1 | tee test-results/pytest.log
       displayName: 'Run tests'
       env:
-        # LAB_APP_CLIENT_ID is intentionally omitted to match the PR gate build
-        # behaviour (azure-pipelines.yml). Without it, _get_credential() in
-        # lab_config.py raises EnvironmentError and all e2e tests skip or error
-        # gracefully — identical to the PR build result.
-        # Uncomment and set this variable to enable full e2e runs on a
-        # lab-capable agent pool (requires CA-exempt network / internal agent).
-        # LAB_APP_CLIENT_ID: $(LAB_APP_CLIENT_ID)
+        # LAB_APP_CLIENT_ID enables e2e tests against the MSID Lab infrastructure.
+        # Must be set as a pipeline variable to the lab app's client ID
+        # (see https://docs.msidlab.com/accounts/confidentialclient.html).
+        # The matching certificate is retrieved from Key Vault by the steps above.
+        # When unset, all LabBasedTestCase tests skip gracefully.
+        LAB_APP_CLIENT_ID: $(LAB_APP_CLIENT_ID)
         LAB_APP_CLIENT_CERT_PFX_PATH: $(LAB_APP_CLIENT_CERT_PFX_PATH)
 
     - task: PublishTestResults@2

--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -189,6 +189,7 @@ stages:
         # The matching certificate is retrieved from Key Vault by the steps above.
         # When unset, all LabBasedTestCase tests skip gracefully.
         LAB_APP_CLIENT_ID: $(LAB_APP_CLIENT_ID)
+        LAB_APP_TENANT_ID: $(LAB_APP_TENANT_ID)
         LAB_APP_CLIENT_CERT_PFX_PATH: $(LAB_APP_CLIENT_CERT_PFX_PATH)
 
     - task: PublishTestResults@2

--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -122,6 +122,11 @@ stages:
       eq(dependencies.PreBuildCheck.result, 'Succeeded'),
       in(dependencies.Validate.result, 'Succeeded', 'Skipped')
     )
+  variables:
+    # RequestMSIDLAB — the MSID Lab confidential client app used for Key Vault
+    # access and as a test subject. Matches usage in MSAL.js and MSAL Java pipelines.
+    # See https://docs.msidlab.com/accounts/confidentialclient.html
+    LAB_APP_CLIENT_ID: 'f62c5ae3-bf3a-4af5-afa8-a68b800396e9'
   jobs:
   - job: Test
     displayName: 'Run unit tests'
@@ -143,11 +148,9 @@ stages:
           python.version: '3.14'
     steps:
     # Retrieve the MSID Lab certificate from Key Vault (via AuthSdkResourceManager SC).
-    # Gated on LAB_APP_CLIENT_ID being non-empty — if e2e tests are not enabled (the default),
-    # both steps are skipped and the pipeline has no Key Vault dependency.
+    # Matches the pattern used by MSAL.js (install-keyvault-secrets.yml) and MSAL Java.
     - task: AzureKeyVault@2
       displayName: 'Retrieve lab certificate from Key Vault'
-      condition: and(succeeded(), ne(variables['LAB_APP_CLIENT_ID'], ''))
       inputs:
         azureSubscription: 'AuthSdkResourceManager'
         KeyVaultName: 'msidlabs'
@@ -161,7 +164,6 @@ stages:
         echo "##vso[task.setvariable variable=LAB_APP_CLIENT_CERT_PFX_PATH]$CERT_PATH"
         echo "Lab cert written to: $CERT_PATH ($(wc -c < "$CERT_PATH") bytes)"
       displayName: 'Write lab certificate to disk'
-      condition: and(succeeded(), ne(variables['LAB_APP_CLIENT_ID'], ''))
 
     - task: UsePythonVersion@0
       inputs:
@@ -183,13 +185,7 @@ stages:
         pytest -vv --junitxml=test-results/junit.xml 2>&1 | tee test-results/pytest.log
       displayName: 'Run tests'
       env:
-        # LAB_APP_CLIENT_ID enables e2e tests against the MSID Lab infrastructure.
-        # Must be set as a pipeline variable to the lab app's client ID
-        # (see https://docs.msidlab.com/accounts/confidentialclient.html).
-        # The matching certificate is retrieved from Key Vault by the steps above.
-        # When unset, all LabBasedTestCase tests skip gracefully.
         LAB_APP_CLIENT_ID: $(LAB_APP_CLIENT_ID)
-        LAB_APP_TENANT_ID: $(LAB_APP_TENANT_ID)
         LAB_APP_CLIENT_CERT_PFX_PATH: $(LAB_APP_CLIENT_CERT_PFX_PATH)
 
     - task: PublishTestResults@2
@@ -203,7 +199,7 @@ stages:
 
     - bash: rm -f "$(Agent.TempDirectory)/lab-auth.pfx"
       displayName: 'Clean up lab certificate'
-      condition: and(always(), ne(variables['LAB_APP_CLIENT_ID'], ''))
+      condition: always()
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Stage 3 · Build — build sdist + wheel (release only)

--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -51,7 +51,7 @@ stages:
     - task: NodeTool@0
       displayName: 'Install Node.js (includes npm)'
       inputs:
-        versionSpec: 'lts/*'
+        versionSpec: '20.x'
 
     - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
       displayName: 'Run PoliCheck'

--- a/tests/lab_config.py
+++ b/tests/lab_config.py
@@ -194,7 +194,12 @@ def _get_credential():
     """
     client_id = _clean_env("LAB_APP_CLIENT_ID")
     cert_path = _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH")
-    tenant_id = "72f988bf-86f1-41af-91ab-2d7cd011db47"  # Microsoft tenant
+    # Allow callers to override the tenant via LAB_APP_TENANT_ID.
+    # Defaults to the Microsoft tenant where the MSID Lab app is registered.
+    tenant_id = (
+        _clean_env("LAB_APP_TENANT_ID")
+        or "72f988bf-86f1-41af-91ab-2d7cd011db47"  # Microsoft tenant
+    )
     
     if not client_id:
         raise EnvironmentError(

--- a/tests/lab_config.py
+++ b/tests/lab_config.py
@@ -164,6 +164,21 @@ _msid_lab_client: Optional[SecretClient] = None
 _msal_team_client: Optional[SecretClient] = None
 
 
+def _clean_env(name: str) -> Optional[str]:
+    """Return the env var value, or None if unset or it contains an unexpanded
+    ADO pipeline variable literal such as ``$(VAR_NAME)``.
+
+    Azure DevOps injects the literal string ``$(VAR_NAME)`` when a ``$(...)``
+    reference in a step ``env:`` block refers to a variable that has not been
+    defined at runtime.  That literal is truthy, so a plain ``os.getenv()``
+    check would incorrectly proceed as if the variable were set.
+    """
+    value = os.getenv(name)
+    if value and value.startswith("$("):
+        return None
+    return value or None
+
+
 def _get_credential():
     """
     Create an Azure credential for Key Vault access.
@@ -177,8 +192,8 @@ def _get_credential():
     Raises:
         EnvironmentError: If required environment variables are not set.
     """
-    client_id = os.getenv("LAB_APP_CLIENT_ID")
-    cert_path = os.getenv("LAB_APP_CLIENT_CERT_PFX_PATH")
+    client_id = _clean_env("LAB_APP_CLIENT_ID")
+    cert_path = _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH")
     tenant_id = "72f988bf-86f1-41af-91ab-2d7cd011db47"  # Microsoft tenant
     
     if not client_id:
@@ -396,7 +411,7 @@ def get_client_certificate() -> Dict[str, object]:
     Raises:
         EnvironmentError: If LAB_APP_CLIENT_CERT_PFX_PATH is not set.
     """
-    cert_path = os.getenv("LAB_APP_CLIENT_CERT_PFX_PATH")
+    cert_path = _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH")
     if not cert_path:
         raise EnvironmentError(
             "LAB_APP_CLIENT_CERT_PFX_PATH environment variable is required "

--- a/tests/lab_config.py
+++ b/tests/lab_config.py
@@ -20,7 +20,6 @@ Usage::
     app = get_app_config(AppSecrets.PCA_CLIENT)
 
 Environment Variables:
-    LAB_APP_CLIENT_ID: Client ID for Key Vault authentication (required)
     LAB_APP_CLIENT_CERT_PFX_PATH: Path to .pfx certificate file (required)
 """
 
@@ -43,6 +42,7 @@ __all__ = [
     "UserConfig",
     "AppConfig",
     # Functions
+    "LAB_APP_CLIENT_ID",
     "get_secret",
     "get_user_config",
     "get_app_config",
@@ -56,6 +56,12 @@ __all__ = [
 
 _MSID_LAB_VAULT = "https://msidlabs.vault.azure.net"
 _MSAL_TEAM_VAULT = "https://id4skeyvault.vault.azure.net"
+
+# Client ID for the RequestMSIDLAB app used to authenticate against the lab
+# Key Vaults. Hardcoded here following the same pattern as MSAL.NET
+# (see build/template-install-keyvault-secrets.yaml in that repo).
+# See https://docs.msidlab.com/accounts/confidentialclient.html
+LAB_APP_CLIENT_ID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9"
 
 # =============================================================================
 # Secret Name Constants
@@ -192,19 +198,14 @@ def _get_credential():
     Raises:
         EnvironmentError: If required environment variables are not set.
     """
-    client_id = _clean_env("LAB_APP_CLIENT_ID")
     cert_path = _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH")
     tenant_id = "72f988bf-86f1-41af-91ab-2d7cd011db47"  # Microsoft tenant
-    
-    if not client_id:
-        raise EnvironmentError(
-            "LAB_APP_CLIENT_ID environment variable is required for Key Vault access")
-    
+
     if cert_path:
         logger.debug("Using certificate credential for Key Vault access")
         return CertificateCredential(
             tenant_id=tenant_id,
-            client_id=client_id,
+            client_id=LAB_APP_CLIENT_ID,
             certificate_path=cert_path,
             send_certificate_chain=True,
         )

--- a/tests/lab_config.py
+++ b/tests/lab_config.py
@@ -194,12 +194,7 @@ def _get_credential():
     """
     client_id = _clean_env("LAB_APP_CLIENT_ID")
     cert_path = _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH")
-    # Allow callers to override the tenant via LAB_APP_TENANT_ID.
-    # Defaults to the Microsoft tenant where the MSID Lab app is registered.
-    tenant_id = (
-        _clean_env("LAB_APP_TENANT_ID")
-        or "72f988bf-86f1-41af-91ab-2d7cd011db47"  # Microsoft tenant
-    )
+    tenant_id = "72f988bf-86f1-41af-91ab-2d7cd011db47"  # Microsoft tenant
     
     if not client_id:
         raise EnvironmentError(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -847,7 +847,6 @@ class AtPopWithExternalKeyTestCase(PopWithExternalKeyTestCase):
 
 
 class WorldWideTestCase(LabBasedTestCase):
-    _ADFS_LABS_UNAVAILABLE = "ADFS labs were temporarily down since July 2025 until further notice"
 
     def test_aad_managed_user(self):  # Pure cloud
         """Test username/password flow for a managed AAD user."""
@@ -862,7 +861,6 @@ class WorldWideTestCase(LabBasedTestCase):
             scope=["https://graph.microsoft.com/.default"],
         )
 
-    @unittest.skip(_ADFS_LABS_UNAVAILABLE)
     def test_adfs2022_fed_user(self):
         """Test username/password flow for a federated user via ADFS 2022."""
         app = get_app_config(AppSecrets.PCA_CLIENT)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,5 +1,4 @@
 """If the following ENV VAR were available, many end-to-end test cases would run.
-LAB_APP_CLIENT_ID=...
 LAB_APP_CLIENT_CERT_PFX_PATH=...
 """
 try:
@@ -29,7 +28,7 @@ from msal.oauth2cli.oidc import decode_part
 from tests.broker_util import is_pymsalruntime_installed
 from tests.lab_config import (
     get_user_config, get_app_config, get_user_password, get_secret,
-    UserSecrets, AppSecrets,
+    UserSecrets, AppSecrets, LAB_APP_CLIENT_ID,
 )
 
 
@@ -348,14 +347,13 @@ class CloudShellTestCase(E2eTestCase):
 class PublicCloudScenariosTestCase(E2eTestCase):
     # Historically this class was driven by tests/config.json for semi-automated runs.
     # It now uses lab config + env vars so it can run automatically on any CI
-    # (including Azure DevOps) as long as LAB_APP_CLIENT_ID and
-    # LAB_APP_CLIENT_CERT_PFX_PATH are set.
+    # (including Azure DevOps) as long as LAB_APP_CLIENT_CERT_PFX_PATH is set.
 
     @classmethod
     def setUpClass(cls):
-        if not _clean_env("LAB_APP_CLIENT_ID"):
+        if not _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH"):
             raise unittest.SkipTest(
-                "LAB_APP_CLIENT_ID not set; skipping PublicCloud e2e tests")
+                "LAB_APP_CLIENT_CERT_PFX_PATH not set; skipping PublicCloud e2e tests")
         pca_app = get_app_config(AppSecrets.PCA_CLIENT)
         user = get_user_config(UserSecrets.PUBLIC_CLOUD)
         cls.config = {
@@ -436,13 +434,11 @@ class PublicCloudScenariosTestCase(E2eTestCase):
 
     def test_subject_name_issuer_authentication(self):
         from tests.lab_config import get_client_certificate
-
-        client_id = os.getenv("LAB_APP_CLIENT_ID")
-        if not client_id:
-            self.skipTest("LAB_APP_CLIENT_ID environment variable is required")
+        if not _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH"):
+            self.skipTest("LAB_APP_CLIENT_CERT_PFX_PATH not set")
 
         self.app = msal.ConfidentialClientApplication(
-            client_id,
+            LAB_APP_CLIENT_ID,
             authority="https://login.microsoftonline.com/microsoft.onmicrosoft.com",
             client_credential=get_client_certificate(),
             http_client=MinimalHttpClient())
@@ -467,7 +463,6 @@ class DeviceFlowTestCase(E2eTestCase):  # A leaf class so it will be run only on
 
 
 def get_lab_app(
-        env_client_id="LAB_APP_CLIENT_ID",
         env_client_cert_path="LAB_APP_CLIENT_CERT_PFX_PATH",
         authority="https://login.microsoftonline.com/"
             "72f988bf-86f1-41af-91ab-2d7cd011db47",  # Microsoft tenant ID
@@ -475,15 +470,15 @@ def get_lab_app(
         **kwargs):
     """Returns the lab app as an MSAL confidential client.
 
-    Get it from environment variables if defined, otherwise fall back to use MSI.
+    Uses the hardcoded lab app client ID (RequestMSIDLAB) and a certificate
+    from the LAB_APP_CLIENT_CERT_PFX_PATH env var.
     """
     logger.info(
-        "Reading ENV variables %s and %s for lab app defined at "
+        "Reading ENV variable %s for lab app defined at "
         "https://docs.msidlab.com/accounts/confidentialclient.html",
-        env_client_id, env_client_cert_path)
-    client_id = _clean_env(env_client_id)
+        env_client_cert_path)
     cert_path = _clean_env(env_client_cert_path)
-    if client_id and cert_path:
+    if cert_path:
         # id came from https://docs.msidlab.com/accounts/confidentialclient.html
         client_credential = {
             "private_key_pfx_path":
@@ -496,7 +491,7 @@ def get_lab_app(
         # See also https://microsoft.sharepoint-df.com/teams/MSIDLABSExtended/SitePages/Programmatically-accessing-LAB-API's.aspx
         raise unittest.SkipTest("MSI-based mechanism has not been implemented yet")
     return msal.ConfidentialClientApplication(
-            client_id,
+            LAB_APP_CLIENT_ID,
             client_credential=client_credential,
             authority=authority,
             http_client=MinimalHttpClient(timeout=timeout),
@@ -1183,15 +1178,13 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
         import os
         from tests.lab_config import get_client_certificate
         
-        # Get client ID from environment and certificate from lab_config
-        client_id = os.getenv("LAB_APP_CLIENT_ID")
-        if not client_id:
-            self.skipTest("LAB_APP_CLIENT_ID environment variable is required")
-        
+        # Get client ID from lab_config constant and certificate from lab_config
+        if not _clean_env("LAB_APP_CLIENT_CERT_PFX_PATH"):
+            self.skipTest("LAB_APP_CLIENT_CERT_PFX_PATH is required")
         client_credential = get_client_certificate()
         
         self.app = msal.ConfidentialClientApplication(
-            client_id,
+            LAB_APP_CLIENT_ID,
             client_credential=client_credential,
             authority="https://login.microsoftonline.com/microsoft.onmicrosoft.com",
             azure_region=configured_region,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -54,6 +54,14 @@ _SKIP_UNATTENDED_E2E_TESTS = (
     os.getenv("TRAVIS") or os.getenv("TF_BUILD") or not os.getenv("CI")
 )
 
+
+def _clean_env(name):
+    """Return the env var value, or None if unset or it contains an unexpanded
+    ADO pipeline variable literal such as ``$(VAR_NAME)``."""
+    value = os.getenv(name)
+    return None if (not value or value.startswith("$(")) else value
+
+
 def _get_app_and_auth_code(
         client_id,
         client_secret=None,
@@ -345,7 +353,7 @@ class PublicCloudScenariosTestCase(E2eTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not os.getenv("LAB_APP_CLIENT_ID"):
+        if not _clean_env("LAB_APP_CLIENT_ID"):
             raise unittest.SkipTest(
                 "LAB_APP_CLIENT_ID not set; skipping PublicCloud e2e tests")
         pca_app = get_app_config(AppSecrets.PCA_CLIENT)
@@ -473,13 +481,14 @@ def get_lab_app(
         "Reading ENV variables %s and %s for lab app defined at "
         "https://docs.msidlab.com/accounts/confidentialclient.html",
         env_client_id, env_client_cert_path)
-    if os.getenv(env_client_id) and os.getenv(env_client_cert_path):
+    client_id = _clean_env(env_client_id)
+    cert_path = _clean_env(env_client_cert_path)
+    if client_id and cert_path:
         # id came from https://docs.msidlab.com/accounts/confidentialclient.html
-        client_id = os.getenv(env_client_id)
         client_credential = {
             "private_key_pfx_path":
                 # Cert came from https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/asset/Microsoft_Azure_KeyVault/Certificate/https://msidlabs.vault.azure.net/certificates/LabAuth
-                os.getenv(env_client_cert_path),
+                cert_path,
             "public_certificate": True,  # Opt in for SNI
             }
     else:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -44,7 +44,15 @@ except ImportError:
 
 _PYMSALRUNTIME_INSTALLED = is_pymsalruntime_installed()
 _AZURE_CLI = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
-_SKIP_UNATTENDED_E2E_TESTS = os.getenv("TRAVIS") or not os.getenv("CI")
+# Skip interactive / browser-dependent tests when:
+#   - on Travis CI (TRAVIS), or
+#   - on Azure DevOps (TF_BUILD) where there is no display/browser on the agent, or
+#   - not running in any CI environment at all (not CI).
+# Service-principal and ROPC tests are NOT gated on this flag; only tests that
+# call acquire_token_interactive() or acquire_token_by_device_flow() are.
+_SKIP_UNATTENDED_E2E_TESTS = (
+    os.getenv("TRAVIS") or os.getenv("TF_BUILD") or not os.getenv("CI")
+)
 
 def _get_app_and_auth_code(
         client_id,
@@ -329,13 +337,17 @@ class CloudShellTestCase(E2eTestCase):
         self.assertIsNotNone(result.get("access_token"))
 
 
-@unittest.skipIf(os.getenv("TF_BUILD"), "Skip PublicCloud scenarios on Azure DevOps")
 class PublicCloudScenariosTestCase(E2eTestCase):
     # Historically this class was driven by tests/config.json for semi-automated runs.
-    # It now uses lab config + env vars so it can run automatically without local files.
+    # It now uses lab config + env vars so it can run automatically on any CI
+    # (including Azure DevOps) as long as LAB_APP_CLIENT_ID and
+    # LAB_APP_CLIENT_CERT_PFX_PATH are set.
 
     @classmethod
     def setUpClass(cls):
+        if not os.getenv("LAB_APP_CLIENT_ID"):
+            raise unittest.SkipTest(
+                "LAB_APP_CLIENT_ID not set; skipping PublicCloud e2e tests")
         pca_app = get_app_config(AppSecrets.PCA_CLIENT)
         user = get_user_config(UserSecrets.PUBLIC_CLOUD)
         cls.config = {


### PR DESCRIPTION
Merges the e2e test fix commits from `RyAuld/fix-e2e-tests` into the pipeline branch.

Key changes:
- Fix e2e test skip logic for undefined ADO pipeline variables
- Enable e2e tests in CI pipeline
- Fix NodeTool versionSpec (lts/* → 20.x) for Windows agents
- MSAL.NET pattern: hardcode LAB_APP_CLIENT_ID in source
- Re-enable test_adfs2022_fed_user (ADFS labs back up)