### PR TITLE
Update pymsalruntime minimum version to 0.20.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,11 +63,11 @@ broker =
     # most existing MSAL Python apps do not have the redirect_uri needed by broker.
     #
     # We need pymsalruntime.CallbackData introduced in PyMsalRuntime 0.14
-    pymsalruntime>=0.14,<0.21; python_version>='3.8' and platform_system=='Windows'
+    pymsalruntime>=0.20.6,<0.21; python_version>='3.8' and platform_system=='Windows'
     # On Mac, PyMsalRuntime 0.17+ is expected to support SSH cert and ROPC
-    pymsalruntime>=0.17,<0.21; python_version>='3.8' and platform_system=='Darwin'
+    pymsalruntime>=0.20.6,<0.21; python_version>='3.8' and platform_system=='Darwin'
     # PyMsalRuntime 0.18+ is expected to support broker on Linux
-    pymsalruntime>=0.18,<0.21; python_version>='3.8' and platform_system=='Linux'
+    pymsalruntime>=0.20.6,<0.21; python_version>='3.8' and platform_system=='Linux'
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
## Summary

Bump the minimum required version of `pymsalruntime` to **0.20.6** across all supported platforms:

| Platform | Before | After |
|----------|--------|-------|
| Windows  | `>=0.14,<0.21` | `>=0.20.6,<0.21` |
| macOS    | `>=0.17,<0.21` | `>=0.20.6,<0.21` |
| Linux    | `>=0.18,<0.21` | `>=0.20.6,<0.21` |