### PR TITLE
Validate region string format before use in URL construction

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -22,7 +22,7 @@ from .wstrust_request import send_request as wst_send_request
 from .wstrust_response import *
 from .token_cache import TokenCache, _get_username, _GRANT_TYPE_BROKER, _compute_ext_cache_key
 import msal.telemetry
-from .region import _detect_region
+from .region import _detect_region, _validate_region
 from .throttled_http_client import ThrottledHttpClient
 from .cloudshell import _is_running_in_cloud_shell
 from .sku import SKU, __version__
@@ -821,6 +821,9 @@ The reserved list: {}""".format(list(scope_set), list(reserved_scope)))
             self._region_detected
             if self._region_configured == self.ATTEMPT_REGION_DISCOVERY
             else self._region_configured)  # It will retain the None i.e. opted out
+        if isinstance(region_to_use, str):
+            region_to_use = _validate_region(
+                region_to_use, source="azure_region parameter")
         logger.debug('Region to be used: {}'.format(repr(region_to_use)))
         if region_to_use:
             regional_host = ("{}.login.microsoft.com".format(region_to_use)

--- a/msal/region.py
+++ b/msal/region.py
@@ -1,13 +1,28 @@
 import os
 import logging
+import re
 
 logger = logging.getLogger(__name__)
+
+_VALID_REGION_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def _validate_region(region, source="unknown"):
+    """Return *region* unchanged if it looks like a valid Azure region name,
+    otherwise log a warning and return ``None``."""
+    if region and _VALID_REGION_RE.match(region):
+        return region
+    if region:
+        logger.warning(
+            "Region from %s was discarded because it contains "
+            "invalid characters: %r", source, region)
+    return None
 
 
 def _detect_region(http_client=None):
     region = os.environ.get("REGION_NAME", "").replace(" ", "").lower()  # e.g. westus2
     if region:
-        return region
+        return _validate_region(region, source="REGION_NAME env variable")
     if http_client:
         return _detect_region_of_azure_vm(http_client)  # It could hang for minutes
     return None
@@ -41,5 +56,5 @@ def _detect_region_of_azure_vm(http_client):
             "IMDS {} unavailable. Perhaps not running in Azure VM?".format(url))
         return None
     else:
-        return resp.text.strip()
+        return _validate_region(resp.text.strip(), source="IMDS endpoint")
 

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,0 +1,59 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from msal.region import _detect_region, _validate_region
+
+
+class TestValidateRegion(unittest.TestCase):
+
+    def test_valid_simple_regions(self):
+        for region in ("eastus", "westus2", "centralindia", "northeurope"):
+            self.assertEqual(_validate_region(region), region)
+
+    def test_valid_hyphenated_regions(self):
+        for region in ("east-us", "west-us-2", "south-central-us"):
+            self.assertEqual(_validate_region(region), region)
+
+    def test_rejects_dots(self):
+        self.assertIsNone(_validate_region("evil.com"))
+
+    def test_rejects_slashes(self):
+        self.assertIsNone(_validate_region("evil.com/path"))
+
+    def test_rejects_colons(self):
+        self.assertIsNone(_validate_region("evil:8080"))
+
+    def test_rejects_uppercase(self):
+        self.assertIsNone(_validate_region("EastUS"))
+
+    def test_rejects_leading_hyphen(self):
+        self.assertIsNone(_validate_region("-eastus"))
+
+    def test_rejects_leading_digit(self):
+        self.assertIsNone(_validate_region("2westus"))
+
+    def test_empty_string(self):
+        self.assertIsNone(_validate_region(""))
+
+    def test_none(self):
+        self.assertIsNone(_validate_region(None))
+
+
+class TestDetectRegion(unittest.TestCase):
+
+    @patch.dict(os.environ, {"REGION_NAME": "westus2"})
+    def test_returns_valid_env_region(self):
+        self.assertEqual(_detect_region(), "westus2")
+
+    @patch.dict(os.environ, {"REGION_NAME": "evil.com/hijack"})
+    def test_rejects_invalid_env_region(self):
+        self.assertIsNone(_detect_region())
+
+    @patch.dict(os.environ, {"REGION_NAME": ""})
+    def test_empty_env_returns_none(self):
+        self.assertIsNone(_detect_region())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #920

## Problem
`_detect_region()` returns the region string from either the `REGION_NAME` environment variable or the IMDS endpoint without validating its format. A user-provided `azure_region` parameter also flows directly into URL construction. If any of these contain unexpected characters (dots, slashes, etc.), the resulting authority URL could be malformed and lead to misdirected requests.

## Solution
Added `_validate_region(region, source)` in `msal/region.py` which checks against `^[a-z][a-z0-9-]*$` (matching the Azure region naming convention, e.g. `eastus`, `westus2`, `east-us-2`). Invalid regions are logged and treated as `None`.

Validation is applied:
- In `_detect_region()` for both the env var and IMDS paths
- In `_get_regional_authority()` for user-provided `azure_region` values

## Tests
Added `tests/test_region.py` covering valid regions, various invalid patterns (dots, slashes, uppercase, leading digits), and env var integration.

## Reference
- MSAL .NET already validates via `RegionManager.ValidateRegion()`
- MSAL Go added validation in https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/625