### PR TITLE
Fix ESRP client ID typo in release pipeline

### DIFF
--- a/.Pipelines/pipeline-publish.yml
+++ b/.Pipelines/pipeline-publish.yml
@@ -166,7 +166,7 @@ stages:
               usemanagedidentity: true
               keyvaultname: 'MSALVault'
               signcertname: 'MSAL-ESRP-Release-Signing'
-              clientid: '8650ce2b-38d4-466a-9144-bc5c19c88112'
+              clientid: '8650ce2b-384d-466a-9144-bc5c19c88112'
               intent: 'PackageDistribution'
               contenttype: 'PyPi'
               contentsource: 'Folder'


### PR DESCRIPTION
## Summary
Fixes a transposition error in the ESRP signing client ID in the publish pipeline.

### Change
- \.Pipelines/pipeline-publish.yml\: corrected client ID from \...38d4...\ to \...384d...\

### Impact
Without this fix, the release pipeline fails at the ESRP signing step because it references a non-existent client.