### PR TITLE
Fix benchmark cache path and add forceBenchmarks pipeline variable

### DIFF
--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -128,6 +128,10 @@ stages:
           --deselect tests/test_cryptography.py::CryptographyTestCase::test_should_be_run_with_latest_version_of_cryptography \
           2>&1 | tee test-results/pytest-unit.log
       displayName: 'Run pytest (unit)'
+      # Python 3.14 intermittently stalls during test execution (likely due to
+      # missing pre-built wheels forcing source compilation or runtime changes).
+      # Cap at 5 minutes to fail fast instead of consuming the full 30-min job timeout.
+      timeoutInMinutes: 5
       env:
         # Force unbuffered stdout so ADO logs stream in real time through the tee pipe.
         PYTHONUNBUFFERED: '1'

--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -94,7 +94,7 @@ stages:
       ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
     strategy:
       matrix:
-        Python39:  { python.version: '3.9'  }
+        Python39:  { python.version: '3.9' }
         Python310: { python.version: '3.10' }
         Python311: { python.version: '3.11' }
         Python312: { python.version: '3.12' }
@@ -128,9 +128,6 @@ stages:
           --deselect tests/test_cryptography.py::CryptographyTestCase::test_should_be_run_with_latest_version_of_cryptography \
           2>&1 | tee test-results/pytest-unit.log
       displayName: 'Run pytest (unit)'
-      # Python 3.14 intermittently stalls during test execution (likely due to
-      # missing pre-built wheels forcing source compilation or runtime changes).
-      # Cap at 5 minutes to fail fast instead of consuming the full 30-min job timeout.
       timeoutInMinutes: 5
       env:
         # Force unbuffered stdout so ADO logs stream in real time through the tee pipe.

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ tests/config.json
 msal_cache.bin
 
 .env
-.perf.baseline
+.perf-baseline/
 
 *.pfx
 .vscode/settings.json

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,11 +74,16 @@ extends:
       condition: |
         and(
           succeeded('E2ETests'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
           or(
-            eq(variables['Build.Reason'], 'IndividualCI'),
-            eq(variables['Build.Reason'], 'BatchedCI'),
-            eq(variables['Build.Reason'], 'Manual')
+            eq(variables['forceBenchmarks'], 'true'),
+            and(
+              eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
+              or(
+                eq(variables['Build.Reason'], 'IndividualCI'),
+                eq(variables['Build.Reason'], 'BatchedCI'),
+                eq(variables['Build.Reason'], 'Manual')
+              )
+            )
           )
         )
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ extends:
             path: $(System.DefaultWorkingDirectory)/.perf-baseline
 
         - bash: |
-            mkdir -p .perf-baseline
+            mkdir -p $(System.DefaultWorkingDirectory)/.perf-baseline
             pytest --benchmark-only --benchmark-json benchmark.json --log-cli-level INFO tests/test_benchmark.py
           displayName: 'Run benchmarks'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,12 +70,15 @@ extends:
     - stage: Benchmark
       displayName: 'Run benchmarks'
       dependsOn: E2ETests
-      # Run on post-merge pushes to dev, or manually when forceBenchmarks=true.
+      # Run on post-merge pushes to dev, or on manual builds when forceBenchmarks=true.
       condition: |
         and(
           succeeded('E2ETests'),
           or(
-            eq(variables['forceBenchmarks'], 'true'),
+            and(
+              eq(variables['Build.Reason'], 'Manual'),
+              in(variables['forceBenchmarks'], 'true', 'True')
+            ),
             and(
               eq(variables['Build.SourceBranch'], 'refs/heads/dev'),
               or(

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,7 @@ extends:
     - stage: Benchmark
       displayName: 'Run benchmarks'
       dependsOn: E2ETests
-      # Only run on post-merge pushes to dev - not on PRs or scheduled runs.
+      # Run on post-merge pushes to dev, or manually when forceBenchmarks=true.
       condition: |
         and(
           succeeded('E2ETests'),

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,9 +105,10 @@ extends:
           displayName: 'Restore performance baseline cache'
           inputs:
             key: 'perf-baseline | "$(Agent.OS)" | tests/test_benchmark.py'
-            path: .perf.baseline
+            path: $(System.DefaultWorkingDirectory)/.perf-baseline
 
         - bash: |
+            mkdir -p .perf-baseline
             pytest --benchmark-only --benchmark-json benchmark.json --log-cli-level INFO tests/test_benchmark.py
           displayName: 'Run benchmarks'
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,10 +1,14 @@
+import os
+from pathlib import Path
+
 from tests.simulator import ClientCredentialGrantSimulator as CcaTester
 from perf_baseline import Baseline
 
 
-import os
-os.makedirs(".perf-baseline", exist_ok=True)
-baseline = Baseline(".perf-baseline/data", threshold=1.5)  # Up to 1.5x slower than baseline
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BASELINE_DIR = _REPO_ROOT / ".perf-baseline"
+os.makedirs(_BASELINE_DIR, exist_ok=True)
+baseline = Baseline(str(_BASELINE_DIR / "data"), threshold=1.5)  # Up to 1.5x slower than baseline
 
 # Here come benchmark test cases, powered by pytest-benchmark
 # Func names will become diag names.

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2,7 +2,7 @@ from tests.simulator import ClientCredentialGrantSimulator as CcaTester
 from perf_baseline import Baseline
 
 
-baseline = Baseline(".perf.baseline", threshold=1.5)  # Up to 1.5x slower than baseline
+baseline = Baseline(".perf-baseline/data", threshold=1.5)  # Up to 1.5x slower than baseline
 
 # Here come benchmark test cases, powered by pytest-benchmark
 # Func names will become diag names.

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -2,6 +2,8 @@ from tests.simulator import ClientCredentialGrantSimulator as CcaTester
 from perf_baseline import Baseline
 
 
+import os
+os.makedirs(".perf-baseline", exist_ok=True)
 baseline = Baseline(".perf-baseline/data", threshold=1.5)  # Up to 1.5x slower than baseline
 
 # Here come benchmark test cases, powered by pytest-benchmark


### PR DESCRIPTION
## Problem

Build [1651184](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1651184&view=results) fails with:

> Please specify path to a directory, File path is not allowed. /home/vsts/work/1/s/.perf.baseline is a file.

The `Cache@2` ADO task requires a directory path, but `.perf.baseline` was configured as a file.

Additionally, Python 3.14 unit tests intermittently stall, consuming the full 30-minute job timeout before being canceled.

## Changes

### Fix benchmark cache path
- Change cache path to `$(System.DefaultWorkingDirectory)/.perf-baseline` (a directory)
- Update `test_benchmark.py` to store baseline data in `.perf-baseline/data`, anchored to repo root via `__file__`
- Ensure the directory is created both in the pipeline (`mkdir -p`) and in test code (`os.makedirs`) so it works in CI and local runs
- Update `.gitignore` to ignore the `.perf-baseline/` directory

### Add `forceBenchmarks` pipeline variable
- Allows benchmarks to run on non-dev branches by setting `forceBenchmarks=true` when queuing a manual build
- Normal CI behavior unchanged (benchmarks still only run automatically on `dev`)

### Add 5-minute step timeout to pytest
- Python 3.14 intermittently stalls during test execution (likely due to missing pre-built wheels or runtime changes)
- Added `timeoutInMinutes: 5` on the pytest step so stalls fail fast instead of consuming the full 30-min job timeout

## Validation

Build [1651236](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1651236&view=results) passed all stages including benchmarks (triggered with `forceBenchmarks=true`).