### PR TITLE
Migrate region discovery to IMDS /compute JSON endpoint

### DIFF
--- a/msal/region.py
+++ b/msal/region.py
@@ -7,6 +7,10 @@ logger = logging.getLogger(__name__)
 
 _VALID_REGION_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 
+# IMDS compute metadata API version used for region auto-discovery.
+# Bump this single constant when moving to a newer IMDS API version.
+_IMDS_API_VERSION = "2021-02-01"
+
 
 def _validate_region(region, source="unknown"):
     """Return *region* unchanged if it looks like a valid Azure region name,
@@ -35,7 +39,7 @@ def _detect_region_of_azure_vm(http_client):
 
         # The region is read from the "location" field of the compute metadata.
         # https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#response-1
-        "?api-version=2021-02-01"
+        "?api-version=" + _IMDS_API_VERSION
         )
     logger.info(
         "Connecting to IMDS {}. "

--- a/msal/region.py
+++ b/msal/region.py
@@ -55,8 +55,14 @@ def _detect_region_of_azure_vm(http_client):
     else:
         try:
             location = json.loads(resp.text).get("location")
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, TypeError):
+            # ValueError: body is not valid JSON;
+            # AttributeError: body is valid JSON but not a JSON object;
+            # TypeError: resp.text is not a string (e.g. a custom http_client).
             logger.info("IMDS {} returned a malformed response.".format(url))
+            return None
+        if location is not None and not isinstance(location, str):
+            logger.info("IMDS {} returned a non-string location.".format(url))
             return None
         return _validate_region(location, source="IMDS endpoint")
 

--- a/msal/region.py
+++ b/msal/region.py
@@ -1,3 +1,4 @@
+import json
 import os
 import logging
 import re
@@ -30,15 +31,11 @@ def _detect_region(http_client=None):
 
 def _detect_region_of_azure_vm(http_client):
     url = (
-        "http://169.254.169.254/metadata/instance"
+        "http://169.254.169.254/metadata/instance/compute"
 
-        # Utilize the "route parameters" feature to obtain region as a string
-        # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#route-parameters
-        "/compute/location?format=text"
-
-        # Location info is available since API version 2017-04-02
-        # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service?tabs=linux#response-1
-        "&api-version=2021-01-01"
+        # The region is read from the "location" field of the compute metadata.
+        # https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#response-1
+        "?api-version=2021-02-01"
         )
     logger.info(
         "Connecting to IMDS {}. "
@@ -56,5 +53,10 @@ def _detect_region_of_azure_vm(http_client):
             "IMDS {} unavailable. Perhaps not running in Azure VM?".format(url))
         return None
     else:
-        return _validate_region(resp.text.strip(), source="IMDS endpoint")
+        try:
+            location = json.loads(resp.text).get("location")
+        except (ValueError, AttributeError):
+            logger.info("IMDS {} returned a malformed response.".format(url))
+            return None
+        return _validate_region(location, source="IMDS endpoint")
 

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -2,7 +2,30 @@ import os
 import unittest
 from unittest.mock import patch
 
-from msal.region import _detect_region, _validate_region
+from msal.region import (
+    _detect_region, _detect_region_of_azure_vm, _validate_region)
+
+from tests.http_client import MinimalResponse
+
+
+class _StubHttpClient(object):
+    """Records the requested URL/headers and returns a preconfigured response.
+
+    If *response* is an exception instance, it is raised from ``get`` to
+    simulate a network failure (e.g. not running in an Azure VM)."""
+
+    def __init__(self, response):
+        self._response = response
+        self.url = None
+        self.headers = None
+
+    def get(self, url, params=None, headers=None, **kwargs):
+        self.url = url
+        self.headers = headers
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
 
 
 class TestValidateRegion(unittest.TestCase):
@@ -53,6 +76,49 @@ class TestDetectRegion(unittest.TestCase):
     @patch.dict(os.environ, {"REGION_NAME": ""})
     def test_empty_env_returns_none(self):
         self.assertIsNone(_detect_region())
+
+
+class TestDetectRegionOfAzureVm(unittest.TestCase):
+
+    def test_valid_location_is_returned(self):
+        client = _StubHttpClient(
+            MinimalResponse(status_code=200, text='{"location": "westus2"}'))
+        self.assertEqual(_detect_region_of_azure_vm(client), "westus2")
+
+    def test_request_uses_compute_json_endpoint(self):
+        client = _StubHttpClient(
+            MinimalResponse(status_code=200, text='{"location": "westus2"}'))
+        _detect_region_of_azure_vm(client)
+        self.assertEqual(
+            client.url,
+            "http://169.254.169.254/metadata/instance/compute"
+            "?api-version=2021-02-01")
+        self.assertNotIn("/location", client.url)
+        self.assertNotIn("format=text", client.url)
+        self.assertEqual(client.headers, {"Metadata": "true"})
+
+    def test_missing_location_returns_none(self):
+        client = _StubHttpClient(MinimalResponse(status_code=200, text="{}"))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_null_location_returns_none(self):
+        client = _StubHttpClient(
+            MinimalResponse(status_code=200, text='{"location": null}'))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_malformed_json_returns_none(self):
+        client = _StubHttpClient(
+            MinimalResponse(status_code=200, text="not json"))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_invalid_location_value_returns_none(self):
+        client = _StubHttpClient(
+            MinimalResponse(status_code=200, text='{"location": "evil.com/hijack"}'))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_network_failure_returns_none(self):
+        client = _StubHttpClient(IOError("IMDS unreachable"))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
 
 
 if __name__ == "__main__":

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from msal.region import (
@@ -114,6 +115,17 @@ class TestDetectRegionOfAzureVm(unittest.TestCase):
     def test_invalid_location_value_returns_none(self):
         client = _StubHttpClient(
             MinimalResponse(status_code=200, text='{"location": "evil.com/hijack"}'))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_non_string_location_returns_none(self):
+        client = _StubHttpClient(
+            MinimalResponse(status_code=200, text='{"location": 123}'))
+        self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_non_string_response_text_returns_none(self):
+        # A custom http_client could yield a non-string resp.text; json.loads
+        # would raise TypeError, which must be treated as a malformed response.
+        client = _StubHttpClient(SimpleNamespace(status_code=200, text=None))
         self.assertIsNone(_detect_region_of_azure_vm(client))
 
     def test_network_failure_returns_none(self):


### PR DESCRIPTION
Ports [microsoft-authentication-library-for-dotnet#6057](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6057) to MSAL Python.

## What
Migrates Azure VM region auto-detection from the legacy IMDS **text** endpoint to the newer **JSON** endpoint.

- **Before:** GET http://169.254.169.254/metadata/instance/compute/location?format=text&api-version=2021-01-01 — response body *is* the region string.
- **After:** GET http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01 — region is read from the location field of the JSON body.

## Details
- msal/region.py _detect_region_of_azure_vm: updated URL (dropped /location route param and format=text, bumped api-version to 2021-02-01) and now parses json.loads(resp.text).get("location").
- Missing/null location and malformed JSON funnel into the existing fallback (return None); the network-failure path and _validate_region are unchanged.
- No public API, telemetry, or config changes. REGION_NAME env-var precedence preserved.

## Tests
Added `TestDetectRegionOfAzureVm` to 	ests/test_region.py: valid location, missing/null location, malformed JSON, invalid region value, network failure, and an assertion on the new request URL/headers. All 20 tests in 	ests/test_region.py pass.