### PR TITLE
Fix Python 3.14 test timeout: replace utcnow() and remove tee pipe

### DIFF
--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -121,16 +121,15 @@ stages:
           --benchmark-skip \
           --timeout=120 \
           --junitxml=test-results/junit-unit.xml \
+          --log-file=test-results/pytest-unit.log \
           --ignore=tests/test_e2e.py \
           --ignore=tests/test_e2e_manual.py \
           --ignore=tests/test_fmi_e2e.py \
           --deselect tests/test_cryptography.py::CryptographyTestCase::test_ceiling_should_be_latest_cryptography_version_plus_three \
-          --deselect tests/test_cryptography.py::CryptographyTestCase::test_should_be_run_with_latest_version_of_cryptography \
-          2>&1 | tee test-results/pytest-unit.log
+          --deselect tests/test_cryptography.py::CryptographyTestCase::test_should_be_run_with_latest_version_of_cryptography
       displayName: 'Run pytest (unit)'
       timeoutInMinutes: 5
       env:
-        # Force unbuffered stdout so ADO logs stream in real time through the tee pipe.
         PYTHONUNBUFFERED: '1'
 
     # Run cryptography version-gating tests separately as a warning-only check.

--- a/msal/wstrust_request.py
+++ b/msal/wstrust_request.py
@@ -26,7 +26,7 @@
 #------------------------------------------------------------------------------
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import logging
 
 from .mex import Mex
@@ -76,7 +76,7 @@ def wsu_time_format(datetime_obj):
 
 
 def _build_rst(username, password, cloud_audience_urn, endpoint_address, soap_action):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return """<s:Envelope xmlns:s='{s}' xmlns:wsa='{wsa}' xmlns:wsu='{wsu}'>
         <s:Header>
             <wsa:Action s:mustUnderstand='1'>{soap_action}</wsa:Action>


### PR DESCRIPTION
## Problem

Python 3.14 unit tests intermittently stall at 99% completion, hitting the 5-minute step timeout. The last output before the hang is:

\\\
##[warning]datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
\\\

## Root Cause

Two issues contribute:

1. **\datetime.utcnow()\ deprecation** — emits a \DeprecationWarning\ on Python 3.12+ and is scheduled for removal in 3.14+
2. **\2>&1 | tee\ pipe deadlock** — after pytest finishes, the pipe to \	ee\ can hang waiting for file descriptors to close on Python 3.14

## Fix

- Replace \datetime.utcnow()\ with \datetime.now(timezone.utc)\ in \msal/wstrust_request.py\ (compatible with Python 3.2+)
- Replace \2>&1 | tee test-results/pytest-unit.log\ with pytest's native \--log-file\ option, eliminating the pipe entirely

## Testing

- Local wstrust tests pass
- CI results from this PR will confirm the fix across all Python versions