### PR TITLE
Remove pytest-azurepipelines plugin to fix Python 3.14 stall

### DIFF
--- a/.Pipelines/template-pipeline-stages.yml
+++ b/.Pipelines/template-pipeline-stages.yml
@@ -111,7 +111,7 @@ stages:
         set -euo pipefail
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest pytest-azurepipelines pytest-timeout
+        pip install pytest pytest-timeout
       displayName: 'Install Python dependencies'
 
     - bash: |
@@ -246,7 +246,7 @@ stages:
         set -euo pipefail
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest pytest-azurepipelines pytest-timeout
+        pip install pytest pytest-timeout
       displayName: 'Install Python dependencies'
 
     - bash: |


### PR DESCRIPTION
## Problem

Python 3.14 unit tests intermittently stall at 99-100% completion, hanging until the 5-minute step timeout. All other Python versions (3.9–3.13) complete in ~1.5 minutes. See #935.

## Root Cause

The \pytest-azurepipelines\ plugin hooks into pytest's session finalization to upload test results to ADO. On Python 3.14, this intermittently hangs the process.

**Evidence:** Tests pass locally on Python 3.14 in 51 seconds (304 passed) without the plugin installed.

## Fix

Remove \pytest-azurepipelines\ from pip install — it's unnecessary since:
- \--junitxml\ already captures test results to XML
- The \PublishTestResults\ task handles uploading to ADO

## Testing

- Local Python 3.14: 304 passed in 50.98s ✅
- CI results from this PR will confirm the fix across all versions