### PR TITLE
Harden regional authority validation

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -14,6 +14,7 @@ from .oauth2cli.oidc import decode_part
 from .authority import (
     Authority,
     WORLD_WIDE,
+    WELL_KNOWN_AUTHORITY_HOSTS,
     _get_instance_discovery_endpoint,
     _get_instance_discovery_host,
 )
@@ -31,6 +32,16 @@ from .oauth2cli.authcode import is_wsl
 
 logger = logging.getLogger(__name__)
 _AUTHORITY_TYPE_CLOUDSHELL = "CLOUDSHELL"
+
+
+def _validate_explicit_region(region, name):
+    if not _validate_region(region, source=name):
+        raise ValueError(
+            "Invalid {}={!r}. It must be a lowercase DNS label that starts "
+            "with a letter, contains only letters, digits, and internal "
+            "hyphens, and is at most 63 characters.".format(name, region))
+    return region
+
 
 def _init_broker(enable_pii_log):  # Make it a function to allow mocking
     from . import broker  # Trigger Broker's initialization, lazily
@@ -670,6 +681,13 @@ class ClientApplication(object):
         self.client_claims = client_claims
         self._client_capabilities = client_capabilities
         self._instance_discovery = instance_discovery
+        if isinstance(azure_region, str):
+            _validate_explicit_region(azure_region, "azure_region")
+        force_region = None
+        if azure_region is None and client_credential:
+            force_region = os.getenv("MSAL_FORCE_REGION")
+            if force_region is not None:
+                _validate_explicit_region(force_region, "MSAL_FORCE_REGION")
 
         if exclude_scopes and not isinstance(exclude_scopes, list):
             raise ValueError(
@@ -717,8 +735,8 @@ class ClientApplication(object):
         if isinstance(authority, str) and urlparse(authority).path.startswith(
             "/dstsv2"):  # dSTS authority's path always starts with "/dstsv2"
             oidc_authority = authority  # So we treat it as if an oidc_authority
+        authority_to_use = authority or "https://{}/common/".format(WORLD_WIDE)
         try:
-            authority_to_use = authority or "https://{}/common/".format(WORLD_WIDE)
             self.authority = Authority(
                 authority_to_use,
                 self.http_client,
@@ -726,22 +744,23 @@ class ClientApplication(object):
                 instance_discovery=self._instance_discovery,
                 oidc_authority_url=oidc_authority,
                 )
-        except ValueError:  # Those are explicit authority validation errors
-            raise
-        except Exception:  # The rest are typically connection errors
-            if validate_authority and not oidc_authority and (
-                azure_region  # Opted in to use region
-                or (azure_region is None and os.getenv("MSAL_FORCE_REGION"))  # Will use region
-            ):
-                # Since caller opts in to use region, here we tolerate connection
-                # errors happened during authority validation at non-region endpoint
-                self.authority = Authority(
-                    authority_to_use,
-                    self.http_client,
-                    instance_discovery=False,
-                    )
-            else:
+        except OSError:
+            authority_host = urlparse(str(authority_to_use)).hostname
+            if not (
+                    validate_authority
+                    and not oidc_authority
+                    and authority_host in WELL_KNOWN_AUTHORITY_HOSTS
+                    and (
+                        azure_region
+                        or force_region is not None
+                    )):
                 raise
+            self.authority = Authority(
+                authority_to_use,
+                self.http_client,
+                validate_authority=True,
+                instance_discovery=False,
+                )
 
         self._decide_broker(allow_broker, enable_pii_log)
         self.token_cache = token_cache or TokenCache()
@@ -843,7 +862,10 @@ The reserved list: {}""".format(list(scope_set), list(reserved_scope)))
         if self._region_configured is False:  # User opts out of ESTS-R
             return None  # Short circuit to completely bypass region detection
         if self._region_configured is None:  # User did not make an ESTS-R choice
-            self._region_configured = os.getenv("MSAL_FORCE_REGION") or None
+            force_region = os.getenv("MSAL_FORCE_REGION")
+            self._region_configured = (
+                _validate_explicit_region(force_region, "MSAL_FORCE_REGION")
+                if force_region is not None else None)
         self._region_detected = self._region_detected or _detect_region(
             self.http_client if self._region_configured is not None else None)
         if (self._region_configured != self.ATTEMPT_REGION_DISCOVERY

--- a/msal/region.py
+++ b/msal/region.py
@@ -5,7 +5,7 @@ import re
 
 logger = logging.getLogger(__name__)
 
-_VALID_REGION_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+_VALID_REGION_RE = re.compile(r"^[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 
 # IMDS compute metadata API version used for region auto-discovery.
 # Bump this single constant when moving to a newer IMDS API version.
@@ -15,7 +15,7 @@ _IMDS_API_VERSION = "2021-02-01"
 def _validate_region(region, source="unknown"):
     """Return *region* unchanged if it looks like a valid Azure region name,
     otherwise log a warning and return ``None``."""
-    if region and _VALID_REGION_RE.match(region):
+    if region and _VALID_REGION_RE.fullmatch(region):
         return region
     if region:
         logger.warning(
@@ -25,7 +25,7 @@ def _validate_region(region, source="unknown"):
 
 
 def _detect_region(http_client=None):
-    region = os.environ.get("REGION_NAME", "").replace(" ", "").lower()  # e.g. westus2
+    region = os.environ.get("REGION_NAME", "")  # e.g. westus2
     if region:
         return _validate_region(region, source="REGION_NAME env variable")
     if http_client:
@@ -69,4 +69,3 @@ def _detect_region_of_azure_vm(http_client):
             logger.info("IMDS {} returned a non-string location.".format(url))
             return None
         return _validate_region(location, source="IMDS endpoint")
-

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+import os
 import sys
 import time
 import warnings
@@ -63,6 +64,163 @@ class TestBytesConversion(unittest.TestCase):
 
     def test_bytes_to_bytes(self):
         self.assertEqual(type(_str2bytes(b"some bytes")), type(b"bytes"))
+
+
+class TestAuthorityValidationWithRegionalMode(unittest.TestCase):
+    authority = "https://untrusted.example/tenant"
+    metadata = {
+        "authorization_endpoint": (
+            "https://untrusted.example/tenant/oauth2/v2.0/authorize"),
+        "token_endpoint": "https://untrusted.example/tenant/oauth2/v2.0/token",
+        "issuer": "https://untrusted.example/tenant/v2.0",
+    }
+
+    def test_unknown_authority_fails_closed_when_region_is_enabled(self):
+        with patch("msal.authority._instance_discovery") as instance_discovery, \
+                patch("msal.authority.tenant_discovery") as tenant_discovery:
+            instance_discovery.return_value = {"error": "invalid_instance"}
+            with self.assertRaisesRegex(ValueError, "invalid_instance"):
+                ClientApplication(
+                    "id", authority=self.authority, azure_region="westus")
+
+        instance_discovery.assert_called_once()
+        tenant_discovery.assert_not_called()
+
+    def test_invalid_oidc_metadata_is_not_retried_without_validation(self):
+        with patch("msal.authority._instance_discovery") as instance_discovery, \
+                patch("msal.authority.tenant_discovery") as tenant_discovery:
+            instance_discovery.return_value = {
+                "tenant_discovery_endpoint": (
+                    "https://untrusted.example/tenant/v2.0/"
+                    ".well-known/openid-configuration")}
+            tenant_discovery.return_value = {
+                "issuer": "https://untrusted.example/tenant/v2.0"}
+            with self.assertRaises(KeyError):
+                ClientApplication(
+                    "id", authority=self.authority, azure_region="westus")
+
+        instance_discovery.assert_called_once()
+        tenant_discovery.assert_called_once()
+
+    def test_invalid_oidc_endpoint_is_not_retried_without_validation(self):
+        with patch("msal.authority._instance_discovery") as instance_discovery, \
+                patch("msal.authority.tenant_discovery") as tenant_discovery:
+            instance_discovery.return_value = {
+                "tenant_discovery_endpoint": (
+                    "https://untrusted.example/tenant/v2.0/"
+                    ".well-known/openid-configuration")}
+            tenant_discovery.return_value = {
+                "authorization_endpoint": (
+                    "https://untrusted.example/tenant/oauth2/v2.0/authorize"),
+                "token_endpoint": None,
+                "issuer": "https://untrusted.example/tenant/v2.0",
+            }
+            with self.assertRaises(ValueError):
+                ClientApplication(
+                    "id", authority=self.authority, azure_region="westus")
+
+        instance_discovery.assert_called_once()
+        tenant_discovery.assert_called_once()
+
+    def test_transient_discovery_failure_is_not_retried_without_validation(self):
+        with patch("msal.authority._instance_discovery") as instance_discovery, \
+                patch("msal.authority.tenant_discovery") as tenant_discovery:
+            instance_discovery.return_value = {
+                "tenant_discovery_endpoint": (
+                    "https://untrusted.example/tenant/v2.0/"
+                    ".well-known/openid-configuration")}
+            tenant_discovery.side_effect = OSError("network unavailable")
+            with self.assertRaisesRegex(OSError, "network unavailable"):
+                ClientApplication(
+                    "id", authority=self.authority, azure_region="westus")
+
+        instance_discovery.assert_called_once()
+        tenant_discovery.assert_called_once()
+
+    def test_known_authority_retries_transient_network_failure(self):
+        safe_authority = "https://login.microsoftonline.com/tenant"
+        safe_metadata = {
+            "authorization_endpoint": (
+                "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize"),
+            "token_endpoint": (
+                "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"),
+            "issuer": "https://login.microsoftonline.com/tenant/v2.0",
+        }
+        with patch("msal.authority._instance_discovery") as instance_discovery, \
+                patch("msal.authority.tenant_discovery") as tenant_discovery:
+            tenant_discovery.side_effect = [
+                OSError("network unavailable"), safe_metadata]
+            app = ClientApplication(
+                "id", authority=safe_authority, azure_region="westus")
+
+        self.assertEqual("login.microsoftonline.com", app.authority.instance)
+        instance_discovery.assert_not_called()
+        self.assertEqual(2, tenant_discovery.call_count)
+
+    def test_invalid_explicit_region_fails_before_authority_construction(self):
+        for region in ("westus-", "a" * 64, "westus2.login.microsoft.com"):
+            with self.subTest(region=region):
+                with self.assertRaisesRegex(ValueError, "Invalid azure_region"):
+                    ClientApplication(
+                        "id", authority=self.authority, azure_region=region)
+
+    @patch.dict(os.environ, {"MSAL_FORCE_REGION": "westus-"})
+    def test_invalid_force_region_fails_before_authority_construction(self):
+        with self.assertRaisesRegex(ValueError, "Invalid MSAL_FORCE_REGION"):
+            ConfidentialClientApplication(
+                "id", client_credential="secret", authority=self.authority)
+
+    @patch.dict(os.environ, {"MSAL_FORCE_REGION": ""})
+    def test_empty_force_region_fails_before_authority_construction(self):
+        with self.assertRaisesRegex(ValueError, "Invalid MSAL_FORCE_REGION"):
+            ConfidentialClientApplication(
+                "id", client_credential="secret", authority=self.authority)
+
+    @patch.dict(os.environ, {"MSAL_FORCE_REGION": "westus-"})
+    @patch(_OIDC_DISCOVERY, new=_OIDC_DISCOVERY_MOCK)
+    def test_invalid_force_region_does_not_affect_public_client(self):
+        app = PublicClientApplication(
+            "id", authority="https://login.microsoftonline.com/tenant")
+
+        self.assertEqual("login.microsoftonline.com", app.authority.instance)
+
+    @patch.dict(os.environ, {"REGION_NAME": "westus-"})
+    @patch(_OIDC_DISCOVERY, new=_OIDC_DISCOVERY_MOCK)
+    def test_invalid_detected_region_uses_global_authority(self):
+        app = ConfidentialClientApplication(
+            "id", client_credential="secret",
+            authority="https://login.microsoftonline.com/tenant",
+            azure_region=True)
+
+        self.assertIsNone(app._regional_client)
+
+    def test_invalid_oidc_issuer_fails_closed(self):
+        with patch("msal.authority.tenant_discovery", return_value={
+                "authorization_endpoint": (
+                    "https://trusted.example/tenant/oauth2/v2.0/authorize"),
+                "token_endpoint": (
+                    "https://trusted.example/tenant/oauth2/v2.0/token"),
+                "issuer": "https://untrusted.example/tenant/v2.0",
+                }) as tenant_discovery:
+            with self.assertRaisesRegex(ValueError, "issuer"):
+                ClientApplication(
+                    "id", oidc_authority="https://trusted.example/tenant",
+                    azure_region="westus")
+
+        tenant_discovery.assert_called_once()
+
+    def test_validate_authority_false_remains_an_explicit_opt_out(self):
+        with patch.dict(os.environ, {"REGION_NAME": "westus"}), \
+                patch("msal.authority._instance_discovery") as instance_discovery, \
+                patch("msal.authority.tenant_discovery",
+                    return_value=self.metadata):
+            app = ConfidentialClientApplication(
+                "id", client_credential="secret", authority=self.authority,
+                azure_region="westus", validate_authority=False)
+
+        self.assertEqual("untrusted.example", app.authority.instance)
+        self.assertIsNotNone(app._regional_client)
+        instance_discovery.assert_not_called()
 
 
 class TestClientApplicationAcquireTokenSilentErrorBehaviors(unittest.TestCase):

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -8,6 +8,7 @@ import sys
 import time
 import warnings
 from unittest.mock import patch, Mock
+from requests.exceptions import ConnectionError as RequestsConnectionError
 import msal
 from msal.application import (
     extract_certs,
@@ -149,7 +150,7 @@ class TestAuthorityValidationWithRegionalMode(unittest.TestCase):
         with patch("msal.authority._instance_discovery") as instance_discovery, \
                 patch("msal.authority.tenant_discovery") as tenant_discovery:
             tenant_discovery.side_effect = [
-                OSError("network unavailable"), safe_metadata]
+                RequestsConnectionError("network unavailable"), safe_metadata]
             app = ClientApplication(
                 "id", authority=safe_authority, azure_region="westus")
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1229,10 +1229,10 @@ class WorldWideRegionalEndpointTestCase(LabBasedTestCase):
             msal.ConfidentialClientApplication.ATTEMPT_REGION_DISCOVERY, "eastus")
         del os.environ["REGION_NAME"]
 
-    def test_acquire_token_for_client_should_use_an_env_var_with_long_region_name(self):
+    def test_acquire_token_for_client_should_ignore_malformed_env_region(self):
         os.environ["REGION_NAME"] = "East Us 2"
         self._test_acquire_token_for_client(
-            msal.ConfidentialClientApplication.ATTEMPT_REGION_DISCOVERY, "eastus2")
+            msal.ConfidentialClientApplication.ATTEMPT_REGION_DISCOVERY, None)
         del os.environ["REGION_NAME"]
 
     def test_cca_obo_should_bypass_regional_endpoint_therefore_still_work(self):

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -57,6 +57,20 @@ class TestValidateRegion(unittest.TestCase):
     def test_rejects_leading_digit(self):
         self.assertIsNone(_validate_region("2westus"))
 
+    def test_rejects_trailing_hyphen(self):
+        self.assertIsNone(_validate_region("westus-"))
+
+    def test_rejects_label_longer_than_63_characters(self):
+        self.assertIsNone(_validate_region("a" * 64))
+
+    def test_rejects_adversarial_dns_labels(self):
+        for region in (
+                "EastUS", "east us", " eastus", "eastus ", "eastus\n",
+                "westus2.login.microsoft.com", "https://westus2",
+                "westus2:443", "westus2/path", "wéstus"):
+            with self.subTest(region=region):
+                self.assertIsNone(_validate_region(region))
+
     def test_empty_string(self):
         self.assertIsNone(_validate_region(""))
 
@@ -73,6 +87,12 @@ class TestDetectRegion(unittest.TestCase):
     @patch.dict(os.environ, {"REGION_NAME": "evil.com/hijack"})
     def test_rejects_invalid_env_region(self):
         self.assertIsNone(_detect_region())
+
+    def test_rejects_unnormalized_env_regions(self):
+        for region in ("EastUS", "East Us 2", "westus-", "a" * 64):
+            with self.subTest(region=region), patch.dict(
+                    os.environ, {"REGION_NAME": region}):
+                self.assertIsNone(_detect_region())
 
     @patch.dict(os.environ, {"REGION_NAME": ""})
     def test_empty_env_returns_none(self):
@@ -116,6 +136,13 @@ class TestDetectRegionOfAzureVm(unittest.TestCase):
         client = _StubHttpClient(
             MinimalResponse(status_code=200, text='{"location": "evil.com/hijack"}'))
         self.assertIsNone(_detect_region_of_azure_vm(client))
+
+    def test_invalid_dns_label_location_returns_none(self):
+        for region in ("westus-", "a" * 64, "westus2:443", "wéstus"):
+            with self.subTest(region=region):
+                client = _StubHttpClient(MinimalResponse(
+                    status_code=200, text='{"location": "%s"}' % region))
+                self.assertIsNone(_detect_region_of_azure_vm(client))
 
     def test_non_string_location_returns_none(self):
         client = _StubHttpClient(


### PR DESCRIPTION
## Summary
- Fail closed for unknown authority and OIDC validation failures when regional mode is enabled.
- Restrict regional resilience to transport failures from well-known Microsoft authority hosts.
- Enforce safe DNS-label validation for explicit and automatically detected regions.

## Tests
- python -m unittest tests.test_application.TestAuthorityValidationWithRegionalMode tests.test_region
- git diff --check

The lab-backed E2E selector was updated for strict raw region handling but could not run locally because its optional zure.identity dependency is not installed.