### PR TITLE
Add WindowsContainerImage definition

### DIFF
--- a/.Pipelines/pipeline-publish.yml
+++ b/.Pipelines/pipeline-publish.yml
@@ -36,6 +36,7 @@ pr: none
 variables:
   CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)]
   system.debug: ${{ parameters.debug }}
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest' # https://aka.ms/obpipelines/containers
 
 resources:
   repositories:


### PR DESCRIPTION
Unlike our other pipelines the MSAL Python pipeline didn't specify a `WindowsContainerImage`, leading to `invalid reference format: repository name (library/$(WindowsContainerImage)) must be lowercase` because `$(WindowsContainerImage)` was treated as a literal string instead of a variable.