### PR TITLE
Retry the token endpoint's POST on a read error

### DIFF
--- a/msal/application.py
+++ b/msal/application.py
@@ -267,6 +267,39 @@ def _msal_extension_check():
             )
 
 
+@functools.lru_cache(maxsize=1)
+def _retry_class(retry_base):
+    """Return a Retry subclass that retries errors on every method, POST included.
+
+    urllib3 retries a read error - a connection reset in the middle of a request, say -
+    only on the methods it considers idempotent, and POST is not one of them. The token
+    endpoint is the only thing MSAL POSTs, so the retry mounted below never applied to
+    it. Status-code retries stay on urllib3's default method set, so a 429 or a 5xx
+    carrying Retry-After still reaches MSAL's own throttling layer, rather than being
+    slept on and retried down here.
+    """
+    default_methods = getattr(
+        retry_base, "DEFAULT_ALLOWED_METHODS", None  # urllib3 1.26+
+        ) or getattr(retry_base, "DEFAULT_METHOD_WHITELIST", frozenset())
+
+    class RetryErrorsOnEveryMethod(retry_base):
+        def is_retry(self, method, status_code, has_retry_after=False):
+            if method is not None and method.upper() not in default_methods:
+                return False
+            return retry_base.is_retry(self, method, status_code, has_retry_after)
+
+    return RetryErrorsOnEveryMethod
+
+
+def _build_retry(requests):
+    """One retry for connection and read errors, on every method."""
+    retry_class = _retry_class(requests.adapters.Retry)
+    try:
+        return retry_class(total=1, allowed_methods=None)  # urllib3 1.26+
+    except TypeError:  # urllib3 < 1.26 spelled it method_whitelist
+        return retry_class(total=1, method_whitelist=None)
+
+
 class ClientApplication(object):
     """You do not usually directly use this class. Use its subclasses instead:
     :class:`PublicClientApplication` and :class:`ConfidentialClientApplication`.
@@ -715,7 +748,7 @@ class ClientApplication(object):
 
             # Enable a minimal retry. Better than nothing.
             # https://github.com/psf/requests/blob/v2.25.1/requests/adapters.py#L94-L108
-            a = requests.adapters.HTTPAdapter(max_retries=1)
+            a = requests.adapters.HTTPAdapter(max_retries=_build_retry(requests))
             self.http_client.mount("http://", a)
             self.http_client.mount("https://", a)
         self.http_client = ThrottledHttpClient(

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -1,0 +1,32 @@
+import requests
+
+from msal.application import _build_retry
+
+from tests import unittest
+
+
+class TestRetryPolicy(unittest.TestCase):
+    """The retry mounted by ClientApplication has to cover the token endpoint's POST,
+    without taking over the 429/5xx handling that MSAL's ThrottledHttpClient does."""
+
+    def setUp(self):
+        self.retry = _build_retry(requests)
+
+    def test_one_retry(self):
+        self.assertEqual(1, self.retry.total)
+
+    def test_errors_are_retried_on_post(self):
+        # urllib3 gates read-error retries on whether it considers the method idempotent
+        self.assertTrue(self.retry._is_method_retryable("POST"))
+        self.assertTrue(self.retry._is_method_retryable("GET"))
+
+    def test_a_throttled_post_is_left_to_msal(self):
+        # A 429 or 5xx with Retry-After on the token endpoint reaches ThrottledHttpClient,
+        # instead of urllib3 sleeping for Retry-After seconds and retrying in place
+        self.assertFalse(self.retry.is_retry("POST", 429, has_retry_after=True))
+        self.assertFalse(self.retry.is_retry("POST", 503, has_retry_after=True))
+
+    def test_a_throttled_get_still_retries(self):
+        # Unchanged from the previous HTTPAdapter(max_retries=1): the discovery GETs
+        # are not throttled by MSAL itself
+        self.assertTrue(self.retry.is_retry("GET", 429, has_retry_after=True))


### PR DESCRIPTION
Fixes #957

`ClientApplication` mounts `HTTPAdapter(max_retries=1)` on its default session under the comment "Enable a minimal retry. Better than nothing.", and the commit that added it (090270d) is titled "Enable retry on connection error". urllib3 retries a read error, a connection reset in the middle of a request say, only on the methods it treats as idempotent, and POST is not one of them. The token endpoint is the only thing MSAL POSTs, so that retry never applied to it.

Measured against a local server that resets the first `/token` connection, with requests 2.34.2, identical on urllib3 2.7.0 and 1.26.20:

| case | today | this PR |
| --- | --- | --- |
| POST, connection refused | retried | retried |
| POST, reset mid-request | not retried | retried |
| GET, reset mid-request | retried | retried |
| POST, 429 with Retry-After | passed through to MSAL | passed through to MSAL |
| GET, 429 with Retry-After | retried by urllib3 | retried by urllib3 |

The change is a `Retry` subclass that widens the error path to every method and leaves the status path on urllib3's default method set. That second half is why it is not simply `Retry(allowed_methods=None)`: that would also switch on urllib3's Retry-After handling for POST, which duplicates `ThrottledHttpClient` and puts a sleep of up to `Retry-After` seconds inside the token call. The last two rows above are unchanged by design.

`allowed_methods` is urllib3 1.26 and newer. Older urllib3 spells it `method_whitelist`, so the constructor falls back on `TypeError`. Checked on Python 3.9 with urllib3 1.25.11, where that fallback is the branch that runs.

One tradeoff worth calling out: a read error means the request may have reached the server, so this can re-send a token request whose response was lost. For `client_credentials` and `refresh_token` that is harmless. For a one-time `authorization_code` the retry comes back `invalid_grant` instead of a connection error. If you would rather not take that, the alternative is to leave POST alone and drop the "minimal retry" comment, since connection errors already retry today and read errors are the only gap.

Tests: `tests/test_http_retry.py` pins that errors retry on POST, that a throttled POST is still left to MSAL, and that the throttled GET behaviour is unchanged. 263 passed, 8 skipped across the offline test files. End to end with the repro from the issue, the default client now gets its token after the reset on both urllib3 majors; on `dev` it fails on the first connection.
